### PR TITLE
Add check if sap profile directory exists 

### DIFF
--- a/netweaver/install_aas.sls
+++ b/netweaver/install_aas.sls
@@ -27,8 +27,8 @@ check_sapprofile_directory_exists_{{ instance_name }}:
   file.exists:
     - name: /sapmnt/{{ node.sid.upper() }}/profile
     - retry:
-        attempts: 10
-        interval: 180
+        attempts: 70
+        interval: 30
 
 wait_for_db_{{ instance_name }}:
   hana.available:
@@ -38,6 +38,8 @@ wait_for_db_{{ instance_name }}:
     - password: {{ netweaver.schema.password }}
     - timeout: 5000
     - interval: 30
+    - require:
+      - check_sapprofile_directory_exists_{{ instance_name }}
 
 netweaver_install_{{ instance_name }}:
   netweaver.installed:
@@ -55,7 +57,6 @@ netweaver_install_{{ instance_name }}:
     - additional_dvds: {{ netweaver.additional_dvds }}
     - require:
       - create_aas_inifile_{{ instance_name }}
-      - check_sapprofile_directory_exists_{{ instance_name }}
       - wait_for_db_{{ instance_name }}
     - retry:
         attempts: {{ node.attempts|default(10) }}

--- a/netweaver/install_aas.sls
+++ b/netweaver/install_aas.sls
@@ -23,6 +23,13 @@ create_aas_inifile_{{ instance_name }}:
         hana_password: {{ netweaver.hana.password }}
         hana_inst: {{ hana_instance }}
 
+check_sapprofile_directory_exists_{{ instance_name }}:
+  file.exists:
+    - name: /sapmnt/{{ node.sid.upper() }}/profile
+    - retry:
+        attempts: 10
+        interval: 180
+
 wait_for_db_{{ instance_name }}:
   hana.available:
     - name: {{ netweaver.hana.host }}
@@ -48,6 +55,7 @@ netweaver_install_{{ instance_name }}:
     - additional_dvds: {{ netweaver.additional_dvds }}
     - require:
       - create_aas_inifile_{{ instance_name }}
+      - check_sapprofile_directory_exists_{{ instance_name }}
       - wait_for_db_{{ instance_name }}
     - retry:
         attempts: {{ node.attempts|default(10) }}

--- a/netweaver/install_db.sls
+++ b/netweaver/install_db.sls
@@ -23,6 +23,13 @@ create_db_inifile_{{ instance_name }}:
         hana_password: {{ netweaver.hana.password }}
         hana_inst: {{ hana_instance }}
 
+check_sapprofile_directory_exists_{{ instance_name }}:
+  file.exists:
+    - name: /sapmnt/{{ node.sid.upper() }}/profile
+    - retry:
+        attempts: 10
+        interval: 180
+
 wait_for_hana_{{ instance_name }}:
   hana.available:
     - name: {{ netweaver.hana.host }}
@@ -49,6 +56,7 @@ netweaver_install_{{ instance_name }}:
     - additional_dvds: {{ netweaver.additional_dvds }}
     - require:
       - create_db_inifile_{{ instance_name }}
+      - check_sapprofile_directory_exists_{{ instance_name }}
       - wait_for_hana_{{ instance_name }}
     - retry:
         attempts: {{ node.attempts|default(5) }}

--- a/netweaver/install_db.sls
+++ b/netweaver/install_db.sls
@@ -27,8 +27,8 @@ check_sapprofile_directory_exists_{{ instance_name }}:
   file.exists:
     - name: /sapmnt/{{ node.sid.upper() }}/profile
     - retry:
-        attempts: 10
-        interval: 180
+        attempts: 70
+        interval: 30
 
 wait_for_hana_{{ instance_name }}:
   hana.available:
@@ -38,6 +38,8 @@ wait_for_hana_{{ instance_name }}:
     - password: {{ netweaver.hana.password }}
     - timeout: 5000
     - interval: 30
+    - require:
+      - check_sapprofile_directory_exists_{{ instance_name }}
 
 netweaver_install_{{ instance_name }}:
   netweaver.db_installed:
@@ -56,7 +58,6 @@ netweaver_install_{{ instance_name }}:
     - additional_dvds: {{ netweaver.additional_dvds }}
     - require:
       - create_db_inifile_{{ instance_name }}
-      - check_sapprofile_directory_exists_{{ instance_name }}
       - wait_for_hana_{{ instance_name }}
     - retry:
         attempts: {{ node.attempts|default(5) }}

--- a/netweaver/install_ers.sls
+++ b/netweaver/install_ers.sls
@@ -22,8 +22,8 @@ check_sapprofile_directory_exists_{{ instance_name }}:
   file.exists:
     - name: /sapmnt/{{ node.sid.upper() }}/profile
     - retry:
-        attempts: 10
-        interval: 180
+        attempts: 70
+        interval: 30
 
 netweaver_install_{{ instance_name }}:
   netweaver.installed:

--- a/netweaver/install_ers.sls
+++ b/netweaver/install_ers.sls
@@ -18,6 +18,13 @@ create_ers_inifile_{{ instance_name }}:
         virtual_hostname: {{ node.virtual_host }}
         download_basket: {{ netweaver.sapexe_folder }}
 
+check_sapprofile_directory_exists_{{ instance_name }}:
+  file.exists:
+    - name: /sapmnt/{{ node.sid.upper() }}/profile
+    - retry:
+        attempts: 10
+        interval: 180
+
 netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
@@ -37,6 +44,7 @@ netweaver_install_{{ instance_name }}:
     - interval: 15
     - require:
       - create_ers_inifile_{{ instance_name }}
+      - check_sapprofile_directory_exists_{{ instance_name }}
 
 remove_ers_inifile_{{ instance_name }}:
   file.absent:

--- a/netweaver/install_pas.sls
+++ b/netweaver/install_pas.sls
@@ -24,6 +24,13 @@ create_pas_inifile_{{ instance_name }}:
         hana_password: {{ netweaver.hana.password }}
         hana_inst: {{ hana_instance }}
 
+check_sapprofile_directory_exists_{{ instance_name }}:
+  file.exists:
+    - name: /sapmnt/{{ node.sid.upper() }}/profile
+    - retry:
+        attempts: 10
+        interval: 180
+
 wait_for_db_{{ instance_name }}:
   hana.available:
     - name: {{ netweaver.hana.host }}
@@ -49,6 +56,7 @@ netweaver_install_{{ instance_name }}:
     - additional_dvds: {{ netweaver.additional_dvds }}
     - require:
       - create_pas_inifile_{{ instance_name }}
+      - check_sapprofile_directory_exists_{{ instance_name }}
       - wait_for_db_{{ instance_name }}
     - retry:
         attempts: {{ node.attempts|default(10) }}

--- a/netweaver/install_pas.sls
+++ b/netweaver/install_pas.sls
@@ -28,8 +28,8 @@ check_sapprofile_directory_exists_{{ instance_name }}:
   file.exists:
     - name: /sapmnt/{{ node.sid.upper() }}/profile
     - retry:
-        attempts: 10
-        interval: 180
+        attempts: 70
+        interval: 30
 
 wait_for_db_{{ instance_name }}:
   hana.available:
@@ -39,6 +39,8 @@ wait_for_db_{{ instance_name }}:
     - password: {{ netweaver.schema.password }}
     - timeout: 5000
     - interval: 30
+    - require:
+      - check_sapprofile_directory_exists_{{ instance_name }}
 
 netweaver_install_{{ instance_name }}:
   netweaver.installed:
@@ -56,7 +58,6 @@ netweaver_install_{{ instance_name }}:
     - additional_dvds: {{ netweaver.additional_dvds }}
     - require:
       - create_pas_inifile_{{ instance_name }}
-      - check_sapprofile_directory_exists_{{ instance_name }}
       - wait_for_db_{{ instance_name }}
     - retry:
         attempts: {{ node.attempts|default(10) }}

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Nov  6 00:03:44 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Version bump 0.1.2
+  * Add check if sap profile directory exists before NW components
+    install
+  * Change the retry/interval values for profile directory check
+
+-------------------------------------------------------------------
 Thu Oct 31 11:53:28 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.1.1

--- a/sapnwbootstrap-formula.spec
+++ b/sapnwbootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           sapnwbootstrap-formula
-Version:        0.1.1
+Version:        0.1.2
 Release:        0
 Summary:        SAP Netweaver platform deployment formula
 License:        Apache-2.0


### PR DESCRIPTION
Check if the directory `/sapmnt/{SID}/profile` exists.
This check is to be done before install of ERS, DB, AAS, PAS instances


Using the salt state fn `file.exists` which will check if the path exists in system.
Please also see if the attempts/intervals are optimal.