### PR TITLE
Feature/create sidadm user

### DIFF
--- a/netweaver/setup/init.sls
+++ b/netweaver/setup/init.sls
@@ -1,7 +1,8 @@
 include:
+  - netweaver.setup.packages
   - netweaver.setup.shared_disk
   - netweaver.setup.virtual_addresses
   - netweaver.setup.sap_nfs
   - netweaver.setup.mount
-  - netweaver.setup.packages
+  - netweaver.setup.users
   - netweaver.setup.swap_space

--- a/netweaver/setup/mount.sls
+++ b/netweaver/setup/mount.sls
@@ -29,5 +29,11 @@ mount_ers_{{ instance_name }}:
     - opts:
       - defaults
 
+{% elif node.sap_instance.lower() in ['pas', 'aas'] %}
+
+create_dialog_folder_{{ node.sap_instance.lower() }}_{{ instance_name }}:
+  file.directory:
+    - name: /usr/sap/{{ node.sid.upper() }}/D{{ instance }}
+
 {% endif %}
 {% endfor %}

--- a/netweaver/setup/users.sls
+++ b/netweaver/setup/users.sls
@@ -1,0 +1,41 @@
+{%- from "netweaver/map.jinja" import netweaver with context -%}
+{% set host = grains['host'] %}
+
+{% if netweaver.sidadm_user is defined %}
+{% for node in netweaver.nodes if host == node.host %}
+{% set instance = '{:0>2}'.format(node.instance) %}
+{% set instance_name =  node.sap_instance.lower()~'_'~node.sid~'_'~instance %}
+
+create_sapsys_group_{{ instance_name }}:
+  group.present:
+    - name: sapsys
+    - gid: {{ netweaver.sidadm_user.gid }}
+
+create_sidadm_user_{{ instance_name }}:
+  user.present:
+    - name: {{ node.sid.lower() }}adm
+    - fullname: SAP System Administrator
+    - shell: /bin/csh
+    - home: /home/{{ node.sid.lower() }}adm
+    - uid: {{ netweaver.sidadm_user.uid }}
+    - gid: {{ netweaver.sidadm_user.gid }}
+    - password: {{ node.master_password }}
+    - hash_password: True
+    - groups:
+      - sapsys
+
+{% if node.sap_instance.lower() in ['ascs', 'ers', 'pas', 'aas'] %}
+create_sid_folder_{{ instance_name }}:
+  file.directory:
+    - name: /usr/sap/{{ node.sid.upper() }}
+    - user: {{ node.sid.lower() }}adm
+    - group: sapsys
+    - mode: 755
+    - recurse:
+      - user
+      - group
+      - mode
+{% endif %}
+
+{% endfor %}
+{% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -9,6 +9,11 @@ netweaver:
     192.168.201.117: sapha1db
     192.168.201.118: sapha1pas
     192.168.201.119: sapha1aas
+  # Create sidadm and sapsys user/group.
+  # If this entry exists the user and group will be created before the installation, not otherwise
+  sidadm_user:
+    uid: 1001
+    gid: 1002
   # Clean /sapmnt/{sid} and /usr/sap/{sid}/SYS content. It will only work if ASCS node is defined.
   # True by default
   clean_nfs: True

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 14 16:31:14 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version bump 0.1.4
+  * Add option to create the sidadm user and update NW folders 
+    to that user  
+
+-------------------------------------------------------------------
 Mon Nov 11 12:28:07 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.1.3

--- a/sapnwbootstrap-formula.spec
+++ b/sapnwbootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           sapnwbootstrap-formula
-Version:        0.1.3
+Version:        0.1.4
 Release:        0
 Summary:        SAP Netweaver platform deployment formula
 License:        Apache-2.0

--- a/templates/aas.inifile.params.j2
+++ b/templates/aas.inifile.params.j2
@@ -132,6 +132,10 @@ nwUsers.sidAdmUID =
 # Instance number of the SAP HANA Database server
 storageBasedCopy.hdb.instanceNumber = {{ '{:0>2}'.format(hana_inst) }}
 
+# The instance number of the SAP HANA database server
+# This entry is used in newer versions of NW
+NW_HDB_getDBInfo.instanceNumber = {{ '{:0>2}'.format(hana_inst) }}
+
 # Password of user 'SYSTEM' inside the SAP HANA Database Server
 storageBasedCopy.hdb.systemPassword = {{ hana_password }}
 


### PR DESCRIPTION
sidadm creation is needed for the latest NW version as a previous step. It's not mandatory, but it solves some issues if the NW installation folders are created beforehand as we do in this formula.