### PR TITLE
Provide option to set sapadm and sidadm passwords

### DIFF
--- a/netweaver/ha_cluster.sls
+++ b/netweaver/ha_cluster.sls
@@ -22,7 +22,7 @@ wait_until_systems_installed:
     - dispstatus: GREEN
     - sid: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ node.master_password }}
+    - password: {{ netweaver.master_password }}
     - retry:
         attempts: 20
         interval: 30
@@ -32,7 +32,7 @@ update_sapservices_{{ instance_name }}:
       - name: {{ node.sap_instance.lower() }}
       - sid: {{ node.sid.lower() }}
       - inst: {{ instance }}
-      - password: {{ node.master_password }}
+      - password: {{ netweaver.master_password }}
 
 stop_sap_instance_{{ instance_name }}:
   module.run:
@@ -40,7 +40,7 @@ stop_sap_instance_{{ instance_name }}:
       - function: 'Stop'
       - sid: {{ node.sid.lower() }}
       - inst: {{ instance }}
-      - password: {{ node.master_password }}
+      - password: {{ netweaver.master_password }}
 
 stop_sap_instance_service_{{ instance_name }}:
   module.run:
@@ -48,7 +48,7 @@ stop_sap_instance_service_{{ instance_name }}:
       - function: 'StopService'
       - sid: {{ node.sid.lower() }}
       - inst: {{ instance }}
-      - password: {{ node.master_password }}
+      - password: {{ netweaver.master_password }}
 
 add_ha_scripts_{{ instance_name }}:
   file.append:
@@ -93,7 +93,7 @@ start_sap_instance_service_{{ instance_name }}:
       - function: 'StartService {{ node.sid.upper() }}'
       - sid: {{ node.sid.lower() }}
       - inst: {{ instance }}
-      - password: {{ node.master_password }}
+      - password: {{ netweaver.master_password }}
     - test.sleep:
       - length: 2
 
@@ -103,6 +103,6 @@ start_sap_instance_{{ instance_name }}:
       - function: 'Start'
       - sid: {{ node.sid.lower() }}
       - inst: {{ instance }}
-      - password: {{ node.master_password }}
+      - password: {{ netweaver.master_password }}
 
 {% endfor %}

--- a/netweaver/ha_cluster.sls
+++ b/netweaver/ha_cluster.sls
@@ -22,7 +22,7 @@ wait_until_systems_installed:
     - dispstatus: GREEN
     - sid: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ netweaver.master_password }}
+    - password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
     - retry:
         attempts: 20
         interval: 30
@@ -32,7 +32,7 @@ update_sapservices_{{ instance_name }}:
       - name: {{ node.sap_instance.lower() }}
       - sid: {{ node.sid.lower() }}
       - inst: {{ instance }}
-      - password: {{ netweaver.master_password }}
+      - password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
 
 stop_sap_instance_{{ instance_name }}:
   module.run:
@@ -40,7 +40,7 @@ stop_sap_instance_{{ instance_name }}:
       - function: 'Stop'
       - sid: {{ node.sid.lower() }}
       - inst: {{ instance }}
-      - password: {{ netweaver.master_password }}
+      - password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
 
 stop_sap_instance_service_{{ instance_name }}:
   module.run:
@@ -48,7 +48,7 @@ stop_sap_instance_service_{{ instance_name }}:
       - function: 'StopService'
       - sid: {{ node.sid.lower() }}
       - inst: {{ instance }}
-      - password: {{ netweaver.master_password }}
+      - password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
 
 add_ha_scripts_{{ instance_name }}:
   file.append:
@@ -93,7 +93,7 @@ start_sap_instance_service_{{ instance_name }}:
       - function: 'StartService {{ node.sid.upper() }}'
       - sid: {{ node.sid.lower() }}
       - inst: {{ instance }}
-      - password: {{ netweaver.master_password }}
+      - password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
     - test.sleep:
       - length: 2
 
@@ -103,6 +103,6 @@ start_sap_instance_{{ instance_name }}:
       - function: 'Start'
       - sid: {{ node.sid.lower() }}
       - inst: {{ instance }}
-      - password: {{ netweaver.master_password }}
+      - password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
 
 {% endfor %}

--- a/netweaver/install_aas.sls
+++ b/netweaver/install_aas.sls
@@ -47,7 +47,7 @@ netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ netweaver.sid_adm_password }}
+    - password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
     - software_path: {{ netweaver.swpm_folder }}
     - root_user: {{ node.root_user }}
     - root_password: {{ node.root_password }}

--- a/netweaver/install_aas.sls
+++ b/netweaver/install_aas.sls
@@ -14,6 +14,8 @@ create_aas_inifile_{{ instance_name }}:
     - template: jinja
     - context: # set up context for template aas.inifile.params.j2
         master_password: {{ node.master_password }}
+        sap_adm_password: {{ node.sap_adm_password|default(node.master_password) }}
+        sid_adm_password: {{ node.sid_adm_password|default(node.master_password) }}
         sid: {{ node.sid }}
         instance: {{ instance }}
         virtual_hostname: {{ node.virtual_host }}

--- a/netweaver/install_aas.sls
+++ b/netweaver/install_aas.sls
@@ -47,7 +47,7 @@ netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ netweaver.master_password }}
+    - password: {{ netweaver.sid_adm_password }}
     - software_path: {{ netweaver.swpm_folder }}
     - root_user: {{ node.root_user }}
     - root_password: {{ node.root_password }}

--- a/netweaver/install_aas.sls
+++ b/netweaver/install_aas.sls
@@ -13,9 +13,9 @@ create_aas_inifile_{{ instance_name }}:
     - name: /tmp/aas.inifile.params
     - template: jinja
     - context: # set up context for template aas.inifile.params.j2
-        master_password: {{ node.master_password }}
-        sap_adm_password: {{ node.sap_adm_password|default(node.master_password) }}
-        sid_adm_password: {{ node.sid_adm_password|default(node.master_password) }}
+        master_password: {{ netweaver.master_password }}
+        sap_adm_password: {{ netweaver.sap_adm_password|default(netweaver.master_password) }}
+        sid_adm_password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
         sid: {{ node.sid }}
         instance: {{ instance }}
         virtual_hostname: {{ node.virtual_host }}
@@ -47,7 +47,7 @@ netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ node.master_password }}
+    - password: {{ netweaver.master_password }}
     - software_path: {{ netweaver.swpm_folder }}
     - root_user: {{ node.root_user }}
     - root_password: {{ node.root_password }}

--- a/netweaver/install_ascs.sls
+++ b/netweaver/install_ascs.sls
@@ -13,6 +13,8 @@ create_ascs_inifile_{{ instance_name }}:
     - template: jinja
     - context: # set up context for template ascs.inifile.params.j2
         master_password: {{ node.master_password }}
+        sap_adm_password: {{ node.sap_adm_password|default(node.master_password) }}
+        sid_adm_password: {{ node.sid_adm_password|default(node.master_password) }}
         sid: {{ node.sid }}
         instance: {{ instance }}
         virtual_hostname: {{ node.virtual_host }}

--- a/netweaver/install_ascs.sls
+++ b/netweaver/install_ascs.sls
@@ -24,7 +24,7 @@ netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ netweaver.master_password }}
+    - password: {{ netweaver.sid_adm_password }}
     - software_path: {{ netweaver.swpm_folder }}
     - root_user: {{ node.root_user }}
     - root_password: {{ node.root_password }}

--- a/netweaver/install_ascs.sls
+++ b/netweaver/install_ascs.sls
@@ -12,9 +12,9 @@ create_ascs_inifile_{{ instance_name }}:
     - name: /tmp/ascs.inifile.params
     - template: jinja
     - context: # set up context for template ascs.inifile.params.j2
-        master_password: {{ node.master_password }}
-        sap_adm_password: {{ node.sap_adm_password|default(node.master_password) }}
-        sid_adm_password: {{ node.sid_adm_password|default(node.master_password) }}
+        master_password: {{ netweaver.master_password }}
+        sap_adm_password: {{ netweaver.sap_adm_password|default(netweaver.master_password) }}
+        sid_adm_password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
         sid: {{ node.sid }}
         instance: {{ instance }}
         virtual_hostname: {{ node.virtual_host }}
@@ -24,7 +24,7 @@ netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ node.master_password }}
+    - password: {{ netweaver.master_password }}
     - software_path: {{ netweaver.swpm_folder }}
     - root_user: {{ node.root_user }}
     - root_password: {{ node.root_password }}

--- a/netweaver/install_ascs.sls
+++ b/netweaver/install_ascs.sls
@@ -24,7 +24,7 @@ netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ netweaver.sid_adm_password }}
+    - password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
     - software_path: {{ netweaver.swpm_folder }}
     - root_user: {{ node.root_user }}
     - root_password: {{ node.root_password }}

--- a/netweaver/install_db.sls
+++ b/netweaver/install_db.sls
@@ -14,6 +14,8 @@ create_db_inifile_{{ instance_name }}:
     - template: jinja
     - context: # set up context for template db.inifile.params.j2
         master_password: {{ node.master_password }}
+        sap_adm_password: {{ node.sap_adm_password|default(node.master_password) }}
+        sid_adm_password: {{ node.sid_adm_password|default(node.master_password) }}
         sid: {{ node.sid }}
         download_basket: {{ netweaver.sapexe_folder }}
         schema_name: {{ netweaver.schema.name|default('SAPABAP1') }}

--- a/netweaver/install_db.sls
+++ b/netweaver/install_db.sls
@@ -13,9 +13,9 @@ create_db_inifile_{{ instance_name }}:
     - name: /tmp/db.inifile.params
     - template: jinja
     - context: # set up context for template db.inifile.params.j2
-        master_password: {{ node.master_password }}
-        sap_adm_password: {{ node.sap_adm_password|default(node.master_password) }}
-        sid_adm_password: {{ node.sid_adm_password|default(node.master_password) }}
+        master_password: {{ netweaver.master_password }}
+        sap_adm_password: {{ netweaver.sap_adm_password|default(netweaver.master_password) }}
+        sid_adm_password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
         sid: {{ node.sid }}
         download_basket: {{ netweaver.sapexe_folder }}
         schema_name: {{ netweaver.schema.name|default('SAPABAP1') }}

--- a/netweaver/install_ers.sls
+++ b/netweaver/install_ers.sls
@@ -13,6 +13,8 @@ create_ers_inifile_{{ instance_name }}:
     - template: jinja
     - context: # set up context for template ers.inifile.params.j2
         master_password: {{ node.master_password }}
+        sap_adm_password: {{ node.sap_adm_password|default(node.master_password) }}
+        sid_adm_password: {{ node.sid_adm_password|default(node.master_password) }}
         sid: {{ node.sid }}
         instance: {{ instance }}
         virtual_hostname: {{ node.virtual_host }}

--- a/netweaver/install_ers.sls
+++ b/netweaver/install_ers.sls
@@ -31,7 +31,7 @@ netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ netweaver.master_password }}
+    - password: {{ netweaver.sid_adm_password }}
     - software_path: {{ netweaver.swpm_folder }}
     - root_user: {{ node.root_user }}
     - root_password: {{ node.root_password }}

--- a/netweaver/install_ers.sls
+++ b/netweaver/install_ers.sls
@@ -12,9 +12,9 @@ create_ers_inifile_{{ instance_name }}:
     - name: /tmp/ers.inifile.params
     - template: jinja
     - context: # set up context for template ers.inifile.params.j2
-        master_password: {{ node.master_password }}
-        sap_adm_password: {{ node.sap_adm_password|default(node.master_password) }}
-        sid_adm_password: {{ node.sid_adm_password|default(node.master_password) }}
+        master_password: {{ netweaver.master_password }}
+        sap_adm_password: {{ netweaver.sap_adm_password|default(netweaver.master_password) }}
+        sid_adm_password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
         sid: {{ node.sid }}
         instance: {{ instance }}
         virtual_hostname: {{ node.virtual_host }}
@@ -31,7 +31,7 @@ netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ node.master_password }}
+    - password: {{ netweaver.master_password }}
     - software_path: {{ netweaver.swpm_folder }}
     - root_user: {{ node.root_user }}
     - root_password: {{ node.root_password }}
@@ -41,7 +41,7 @@ netweaver_install_{{ instance_name }}:
     - product_id: NW_ERS:NW750.HDB.ABAPHA
     - cwd: {{ netweaver.installation_folder }}
     - additional_dvds: {{ netweaver.additional_dvds }}
-    - ascs_password: {{ node.master_password }}
+    - ascs_password: {{ netweaver.master_password }}
     - timeout: 1500
     - interval: 15
     - require:

--- a/netweaver/install_ers.sls
+++ b/netweaver/install_ers.sls
@@ -41,7 +41,7 @@ netweaver_install_{{ instance_name }}:
     - product_id: NW_ERS:NW750.HDB.ABAPHA
     - cwd: {{ netweaver.installation_folder }}
     - additional_dvds: {{ netweaver.additional_dvds }}
-    - ascs_password: {{ netweaver.master_password }}
+    - ascs_password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
     - timeout: 1500
     - interval: 15
     - require:

--- a/netweaver/install_ers.sls
+++ b/netweaver/install_ers.sls
@@ -31,7 +31,7 @@ netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ netweaver.sid_adm_password }}
+    - password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
     - software_path: {{ netweaver.swpm_folder }}
     - root_user: {{ node.root_user }}
     - root_password: {{ node.root_password }}

--- a/netweaver/install_pas.sls
+++ b/netweaver/install_pas.sls
@@ -48,7 +48,7 @@ netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ netweaver.sid_adm_password }}
+    - password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
     - software_path: {{ netweaver.swpm_folder }}
     - root_user: {{ node.root_user }}
     - root_password: {{ node.root_password }}

--- a/netweaver/install_pas.sls
+++ b/netweaver/install_pas.sls
@@ -48,7 +48,7 @@ netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ netweaver.master_password }}
+    - password: {{ netweaver.sid_adm_password }}
     - software_path: {{ netweaver.swpm_folder }}
     - root_user: {{ node.root_user }}
     - root_password: {{ node.root_password }}

--- a/netweaver/install_pas.sls
+++ b/netweaver/install_pas.sls
@@ -13,9 +13,9 @@ create_pas_inifile_{{ instance_name }}:
     - name: /tmp/pas.inifile.params
     - template: jinja
     - context: # set up context for template pas.inifile.params.j2
-        master_password: {{ node.master_password }}
-        sap_adm_password: {{ node.sap_adm_password|default(node.master_password) }}
-        sid_adm_password: {{ node.sid_adm_password|default(node.master_password) }}
+        master_password: {{ netweaver.master_password }}
+        sap_adm_password: {{ netweaver.sap_adm_password|default(netweaver.master_password) }}
+        sid_adm_password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
         sid: {{ node.sid }}
         instance: {{ instance }}
         virtual_hostname: {{ node.virtual_host }}
@@ -48,7 +48,7 @@ netweaver_install_{{ instance_name }}:
   netweaver.installed:
     - name: {{ node.sid.lower() }}
     - inst: {{ instance }}
-    - password: {{ node.master_password }}
+    - password: {{ netweaver.master_password }}
     - software_path: {{ netweaver.swpm_folder }}
     - root_user: {{ node.root_user }}
     - root_password: {{ node.root_password }}

--- a/netweaver/install_pas.sls
+++ b/netweaver/install_pas.sls
@@ -14,6 +14,8 @@ create_pas_inifile_{{ instance_name }}:
     - template: jinja
     - context: # set up context for template pas.inifile.params.j2
         master_password: {{ node.master_password }}
+        sap_adm_password: {{ node.sap_adm_password|default(node.master_password) }}
+        sid_adm_password: {{ node.sid_adm_password|default(node.master_password) }}
         sid: {{ node.sid }}
         instance: {{ instance }}
         virtual_hostname: {{ node.virtual_host }}

--- a/netweaver/setup/users.sls
+++ b/netweaver/setup/users.sls
@@ -19,7 +19,7 @@ create_sidadm_user_{{ instance_name }}:
     - home: /home/{{ node.sid.lower() }}adm
     - uid: {{ netweaver.sidadm_user.uid }}
     - gid: {{ netweaver.sidadm_user.gid }}
-    - password: {{ node.sid_adm_password|default(node.master_password) }}
+    - password: {{ netweaver.sid_adm_password|default(netweaver.master_password) }}
     - hash_password: True
     - groups:
       - sapsys

--- a/netweaver/setup/users.sls
+++ b/netweaver/setup/users.sls
@@ -19,7 +19,7 @@ create_sidadm_user_{{ instance_name }}:
     - home: /home/{{ node.sid.lower() }}adm
     - uid: {{ netweaver.sidadm_user.uid }}
     - gid: {{ netweaver.sidadm_user.gid }}
-    - password: {{ node.master_password }}
+    - password: {{ node.sid_adm_password|default(node.master_password) }}
     - hash_password: True
     - groups:
       - sapsys

--- a/pillar.example
+++ b/pillar.example
@@ -53,6 +53,10 @@ netweaver:
       root_user: root
       root_password: linux
       master_password: your_password
+      # sap_adm_password is optional, master password will be used as default, if value not provided
+      sap_adm_password: your_sapadm_password
+      # sid_adm_password is optional, master password will be used as default, if value not provided
+      sid_adm_password: your_sidadm_password
       shared_disk_dev: /dev/sbd
       init_shared_disk: True
       sap_instance: ascs
@@ -64,6 +68,8 @@ netweaver:
       root_user: root
       root_password: linux
       master_password: your_password
+      sap_adm_password: your_sapadm_password
+      sid_adm_password: your_sidadm_password
       shared_disk_dev: /dev/sbd
       sap_instance: ers
 
@@ -75,6 +81,8 @@ netweaver:
       root_user: root
       root_password: linux
       master_password: your_password
+      sap_adm_password: your_sapadm_password
+      sid_adm_password: your_sidadm_password
       sap_instance: db
 
     - host: hacert03
@@ -85,6 +93,8 @@ netweaver:
       root_user: root
       root_password: linux
       master_password: your_password
+      sap_adm_password: your_sapadm_password
+      sid_adm_password: your_sidadm_password
       sap_instance: pas
 
     - host: hacert04
@@ -94,4 +104,6 @@ netweaver:
       root_user: root
       root_password: linux
       master_password: your_password
+      sap_adm_password: your_sapadm_password
+      sid_adm_password: your_sidadm_password
       sap_instance: aas

--- a/pillar.example
+++ b/pillar.example
@@ -14,6 +14,12 @@ netweaver:
   sidadm_user:
     uid: 1001
     gid: 1002
+  # sid_adm_password is optional, master password will be used as default, if value is not defined
+  sid_adm_password: your_sidadm_password
+  # sap_adm_password is optional, master password will be used as default, if value is not defined
+  sap_adm_password: your_sapadm_password
+  # Master password is used for all the SAP users that are created
+  master_password: your_password
   # Clean /sapmnt/{sid} and /usr/sap/{sid}/SYS content. It will only work if ASCS node is defined.
   # True by default
   clean_nfs: True
@@ -52,11 +58,6 @@ netweaver:
       instance: 00
       root_user: root
       root_password: linux
-      master_password: your_password
-      # sap_adm_password is optional, master password will be used as default, if value not provided
-      sap_adm_password: your_sapadm_password
-      # sid_adm_password is optional, master password will be used as default, if value not provided
-      sid_adm_password: your_sidadm_password
       shared_disk_dev: /dev/sbd
       init_shared_disk: True
       sap_instance: ascs
@@ -67,9 +68,6 @@ netweaver:
       instance: 10
       root_user: root
       root_password: linux
-      master_password: your_password
-      sap_adm_password: your_sapadm_password
-      sid_adm_password: your_sidadm_password
       shared_disk_dev: /dev/sbd
       sap_instance: ers
 
@@ -80,9 +78,6 @@ netweaver:
       instance: 00
       root_user: root
       root_password: linux
-      master_password: your_password
-      sap_adm_password: your_sapadm_password
-      sid_adm_password: your_sidadm_password
       sap_instance: db
 
     - host: hacert03
@@ -92,9 +87,6 @@ netweaver:
       instance: 01
       root_user: root
       root_password: linux
-      master_password: your_password
-      sap_adm_password: your_sapadm_password
-      sid_adm_password: your_sidadm_password
       sap_instance: pas
 
     - host: hacert04
@@ -103,7 +95,4 @@ netweaver:
       instance: 02
       root_user: root
       root_password: linux
-      master_password: your_password
-      sap_adm_password: your_sapadm_password
-      sid_adm_password: your_sidadm_password
       sap_instance: aas

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
-Thu Dec  5 19:34:23 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
+Mon Dec  9 18:45:49 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
 
-- Version bump 0.1.6
+- Version bump 0.1.7
   * Provide the option to set individual sapadm and <sid>adm passwords
     and set master password as default for all NW instances
 

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec  5 19:34:23 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Version bump 0.1.6
+  * Provide the option to set individual sapadm and <sid>adm passwords
+    and set master password as default for all NW instances
+
+-------------------------------------------------------------------
 Thu Nov 28 10:14:56 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.1.5

--- a/sapnwbootstrap-formula.spec
+++ b/sapnwbootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           sapnwbootstrap-formula
-Version:        0.1.5
+Version:        0.1.6
 Release:        0
 Summary:        SAP Netweaver platform deployment formula
 License:        Apache-2.0

--- a/sapnwbootstrap-formula.spec
+++ b/sapnwbootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           sapnwbootstrap-formula
-Version:        0.1.6
+Version:        0.1.7
 Release:        0
 Summary:        SAP Netweaver platform deployment formula
 License:        Apache-2.0

--- a/templates/aas.inifile.params.j2
+++ b/templates/aas.inifile.params.j2
@@ -106,7 +106,7 @@ archives.downloadBasket = {{ download_basket }}
 # hostAgent.domain =
 
 # Password for the 'sapadm' user of the SAP Host Agent
-# hostAgent.sapAdmPassword =
+hostAgent.sapAdmPassword = {{ sap_adm_password }}
 
 # Windows only: The domain of all users of this SAP system. Leave empty for default.
 # nwUsers.sapDomain =
@@ -124,7 +124,7 @@ nwUsers.sapsysGID =
 nwUsers.sidAdmUID =
 
 # The password of the '<sapsid>adm' user
-# nwUsers.sidadmPassword =
+nwUsers.sidadmPassword = {{ sid_adm_password }}
 
 # ABAP schema password
 # storageBasedCopy.abapSchemaPassword =

--- a/templates/ascs.inifile.params.j2
+++ b/templates/ascs.inifile.params.j2
@@ -87,7 +87,7 @@ archives.downloadBasket = {{ download_basket }}
 # hostAgent.domain =
 
 # Password for the 'sapadm' user of the SAP Host Agent
-# hostAgent.sapAdmPassword =
+hostAgent.sapAdmPassword = {{ sap_adm_password }}
 
 # Windows only: The domain of all users of this SAP system. Leave empty for default.
 # nwUsers.sapDomain =
@@ -105,4 +105,4 @@ nwUsers.sapsysGID =
 nwUsers.sidAdmUID =
 
 # The password of the '<sapsid>adm' user
-# nwUsers.sidadmPassword =
+nwUsers.sidadmPassword = {{ sid_adm_password }}

--- a/templates/db.inifile.params.j2
+++ b/templates/db.inifile.params.j2
@@ -168,7 +168,7 @@ hanadb.landscape.reorg.useParameterFile = DONOTUSEFILE
 # hostAgent.domain =
 
 # Password for the 'sapadm' user of the SAP Host Agent
-hostAgent.sapAdmPassword = {{ master_password }}
+hostAgent.sapAdmPassword = {{ sap_adm_password }}
 
 # Windows only: The domain of all users of this SAP system. Leave empty for default.
 # nwUsers.sapDomain =
@@ -186,7 +186,7 @@ nwUsers.sapsysGID =
 nwUsers.sidAdmUID =
 
 # The password of the '<sapsid>adm' user
-nwUsers.sidadmPassword = {{ master_password }}
+nwUsers.sidadmPassword = {{ sid_adm_password }}
 
 # ABAP schema password
 # storageBasedCopy.abapSchemaPassword =

--- a/templates/ers.inifile.params.j2
+++ b/templates/ers.inifile.params.j2
@@ -16,6 +16,9 @@
 # Specify whether the all operating system users are to be removed from group 'sapinst' after the execution of Software Provisioning Manager has completed.
 NW_Delete_Sapinst_Users.removeUsers = true
 
+# Master password
+NW_GetMasterPassword.masterPwd = {{ master_password }}
+
 # SAP INTERNAL USE ONLY
 # NW_System.installSAPHostAgent = true
 

--- a/templates/ers.inifile.params.j2
+++ b/templates/ers.inifile.params.j2
@@ -44,7 +44,7 @@ archives.downloadBasket = {{ download_basket }}
 # hostAgent.domain =
 
 # Password for the 'sapadm' user of the SAP Host Agent
-hostAgent.sapAdmPassword = {{ master_password }}
+hostAgent.sapAdmPassword = {{ sap_adm_password }}
 
 # Windows only: The domain of all users of this SAP system. Leave empty for default.
 # nwUsers.sapDomain =
@@ -62,7 +62,7 @@ nwUsers.sapsysGID =
 nwUsers.sidAdmUID =
 
 # The password of the '<sapsid>adm' user
-nwUsers.sidadmPassword = {{ master_password }}
+nwUsers.sidadmPassword = {{ sid_adm_password }}
 
 # The  instance number of the ERS instance. Leave empty for default.
 nw_instance_ers.ersInstanceNumber = {{ instance }}

--- a/templates/pas.inifile.params.j2
+++ b/templates/pas.inifile.params.j2
@@ -173,7 +173,7 @@ archives.downloadBasket = {{ download_basket }}
 # hostAgent.domain =
 
 # Password for the 'sapadm' user of the SAP Host Agent
-# hostAgent.sapAdmPassword =
+hostAgent.sapAdmPassword = {{ sap_adm_password }}
 
 # Windows only: The domain of all users of this SAP system. Leave empty for default.
 # nwUsers.sapDomain =
@@ -191,7 +191,7 @@ nwUsers.sapsysGID =
 nwUsers.sidAdmUID =
 
 # The password of the '<sapsid>adm' user
-# nwUsers.sidadmPassword =
+nwUsers.sidadmPassword = {{ sid_adm_password }}
 
 # ABAP schema password
 # storageBasedCopy.abapSchemaPassword =


### PR DESCRIPTION
This PR provides the option to set individual `sapadm` and `<sid>adm` passwords for each NW instance, having the Master password as default. The idea is to provide the same level of configuration a user can modify from the SAP GUI installer.
