### PR TITLE
Fix additional_dvds formatting to remove the u char

### DIFF
--- a/netweaver/install_aas.sls
+++ b/netweaver/install_aas.sls
@@ -54,7 +54,7 @@ netweaver_install_{{ instance_name }}:
     - virtual_host_interface: {{ node.virtual_host_interface|default('eth1') }}
     - product_id: NW_DI:NW750.HDB.ABAPHA
     - cwd: {{ netweaver.installation_folder }}
-    - additional_dvds: {{ netweaver.additional_dvds }}
+    - additional_dvds: {{ netweaver.additional_dvds|json }}
     - require:
       - create_aas_inifile_{{ instance_name }}
       - wait_for_db_{{ instance_name }}

--- a/netweaver/install_ascs.sls
+++ b/netweaver/install_ascs.sls
@@ -31,7 +31,7 @@ netweaver_install_{{ instance_name }}:
     - virtual_host_interface: {{ node.virtual_host_interface|default('eth1') }}
     - product_id: NW_ABAP_ASCS:NW750.HDB.ABAPHA
     - cwd: {{ netweaver.installation_folder }}
-    - additional_dvds: {{ netweaver.additional_dvds }}
+    - additional_dvds: {{ netweaver.additional_dvds|json }}
     - require:
       - create_ascs_inifile_{{ instance_name }}
 

--- a/netweaver/install_db.sls
+++ b/netweaver/install_db.sls
@@ -55,7 +55,7 @@ netweaver_install_{{ instance_name }}:
     - virtual_host_interface: {{ node.virtual_host_interface|default('eth1') }}
     - product_id: NW_ABAP_DB:NW750.HDB.ABAPHA
     - cwd: {{ netweaver.installation_folder }}
-    - additional_dvds: {{ netweaver.additional_dvds }}
+    - additional_dvds: {{ netweaver.additional_dvds|json }}
     - require:
       - create_db_inifile_{{ instance_name }}
       - wait_for_hana_{{ instance_name }}

--- a/netweaver/install_ers.sls
+++ b/netweaver/install_ers.sls
@@ -38,7 +38,7 @@ netweaver_install_{{ instance_name }}:
     - virtual_host_interface: {{ node.virtual_host_interface|default('eth1') }}
     - product_id: NW_ERS:NW750.HDB.ABAPHA
     - cwd: {{ netweaver.installation_folder }}
-    - additional_dvds: {{ netweaver.additional_dvds }}
+    - additional_dvds: {{ netweaver.additional_dvds|json }}
     - ascs_password: {{ node.master_password }}
     - timeout: 1500
     - interval: 15

--- a/netweaver/install_pas.sls
+++ b/netweaver/install_pas.sls
@@ -55,7 +55,7 @@ netweaver_install_{{ instance_name }}:
     - virtual_host_interface: {{ node.virtual_host_interface|default('eth1') }}
     - product_id: NW_ABAP_CI:NW750.HDB.ABAPHA
     - cwd: {{ netweaver.installation_folder }}
-    - additional_dvds: {{ netweaver.additional_dvds }}
+    - additional_dvds: {{ netweaver.additional_dvds|json }}
     - require:
       - create_pas_inifile_{{ instance_name }}
       - wait_for_db_{{ instance_name }}

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,9 +1,16 @@
 -------------------------------------------------------------------
+Thu Nov 28 10:14:56 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version bump 0.1.5
+  * Fix backward compatibility issues with salt versions based in py2
+    to format additional_dvds list correctly to json (remove u char) 
+
+-------------------------------------------------------------------
 Thu Nov 14 16:31:14 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.1.4
-  * Add option to create the sidadm user and update NW folders 
-    to that user  
+  * Add option to create the sidadm user and update NW folders
+    to that user
 
 -------------------------------------------------------------------
 Mon Nov 11 12:28:07 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>

--- a/sapnwbootstrap-formula.spec
+++ b/sapnwbootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           sapnwbootstrap-formula
-Version:        0.1.4
+Version:        0.1.5
 Release:        0
 Summary:        SAP Netweaver platform deployment formula
 License:        Apache-2.0


### PR DESCRIPTION
Fix issue in SLE12 version where the additional_dvds are not correctly used creating this content in th `start_cd.dir` file:

```
/netweaver_inst_media/SWPM_10_SP26_6
u'/netweaver_inst_media/51050829_3'
u'/netweaver_inst_media/51053787'
```

The `json` method fixes the issue. More info:
https://stackoverflow.com/questions/54988262/saltstack-and-strange-unicode-quoting-from-pillar