### PR TITLE
Hotfix/aws stonith action

### DIFF
--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Mar  9 15:55:49 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.2.6
+  * Fix "stonith-action" parameter usage in the HA cluster
+    template for aws
+    (jsc#SLE-4143, boo#1137989)
+
+-------------------------------------------------------------------
 Tue Mar  3 09:52:45 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.2.5

--- a/sapnwbootstrap-formula.spec
+++ b/sapnwbootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           sapnwbootstrap-formula
-Version:        0.2.5
+Version:        0.2.6
 Release:        0
 Summary:        SAP Netweaver platform deployment formula
 License:        Apache-2.0

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -12,12 +12,13 @@
 {%- set ascs_virtual_host = data.ascs_virtual_host %}
 {%- set ers_virtual_host = data.ers_virtual_host %}
 
-# General cluster options
-{%- if cloud_provider not in ["amazon-web-services"] %}
+# Platform dependant (stonith, virtual ip address, cib options, etc) resource
+
+{%- if cloud_provider == "amazon-web-services" %}
 
 property cib-bootstrap-options: \
   stonith-enabled="true" \
-  stonith-action="poweroff" \
+  stonith-action="off" \
   stonith-timeout="600s"
 
 rsc_defaults rsc-options: \
@@ -27,12 +28,6 @@ rsc_defaults rsc-options: \
 op_defaults op-options: \
 	timeout=600 \
 	record-pending=true
-
-{%- endif %}
-
-# Platform dependant (stonith, virtual ip address, cib options, etc) resource
-
-{%- if cloud_provider == "amazon-web-services" %}
 
 primitive res_aws_stonith_{{ sid }} stonith:external/ec2 \
   params tag={{ data.instance_tag }} profile={{ data.cluster_profile}} \


### PR DESCRIPTION
Fix to use `off` instead of `poweroff` in the stonith action (`poweroff` is deprecated and it raises a warning message that block crm commands)
In fact, these configuration will only apply to AWS as the official guides say.