### PR TITLE
Feature/install pydbapi

### DIFF
--- a/netweaver/install_aas.sls
+++ b/netweaver/install_aas.sls
@@ -56,6 +56,7 @@ wait_for_db_{{ instance_name }}:
     - interval: 30
     - require:
       - check_sapprofile_directory_exists_{{ instance_name }}
+      - nw_install_pydbapi_client
 
 netweaver_install_{{ instance_name }}:
   netweaver.installed:

--- a/netweaver/install_db.sls
+++ b/netweaver/install_db.sls
@@ -56,6 +56,7 @@ wait_for_hana_{{ instance_name }}:
     - interval: 30
     - require:
       - check_sapprofile_directory_exists_{{ instance_name }}
+      - nw_install_pydbapi_client
 
 netweaver_install_{{ instance_name }}:
   netweaver.db_installed:

--- a/netweaver/install_pas.sls
+++ b/netweaver/install_pas.sls
@@ -57,6 +57,7 @@ wait_for_db_{{ instance_name }}:
     - interval: 30
     - require:
       - check_sapprofile_directory_exists_{{ instance_name }}
+      - nw_install_pydbapi_client
 
 netweaver_install_{{ instance_name }}:
   netweaver.installed:

--- a/netweaver/setup/init.sls
+++ b/netweaver/setup/init.sls
@@ -1,5 +1,6 @@
 include:
   - netweaver.setup.packages
+  - netweaver.setup.install_pydbapi
   - netweaver.setup.shared_disk
   - netweaver.setup.virtual_addresses
   - netweaver.setup.sap_nfs

--- a/netweaver/setup/install_pydbapi.sls
+++ b/netweaver/setup/install_pydbapi.sls
@@ -1,0 +1,46 @@
+{%- from "netweaver/map.jinja" import netweaver with context -%}
+{% set host = grains['host'] %}
+
+{% for node in netweaver.nodes if node.host == host and node.sap_instance in ['db', 'pas', 'aas'] %}
+{% if loop.first %}
+{% set pydbapi_output_dir = '/tmp/pydbapi' %}
+nw_install_python_pip:
+  pkg.installed:
+    {% if grains['pythonversion'][0] == 2 %}
+    - name: python-pip
+    {% else %}
+    - name: python3-pip
+    {% endif %}
+    - retry:
+        attempts: 3
+        interval: 15
+    - resolve_capabilities: true
+
+nw_extract_pydbapi_client:
+  hana.pydbapi_extracted:
+    - name: PYDBAPI.TGZ
+    - software_folders: {{ netweaver.additional_dvds }}
+    - output_dir: {{ pydbapi_output_dir }}
+    - hana_version: '20'
+    - force: true
+
+# pip.installed fails as it cannot manage propler file names with regular expressions
+# TODO: Improve this to use pip.installed somehow
+nw_install_pydbapi_client:
+  cmd.run:
+    {% if grains['pythonversion'][0] == 2 %}
+    - name: /usr/bin/python -m pip install {{ pydbapi_output_dir }}/hdbcli-*.tar.gz
+    {% else %}
+    - name: /usr/bin/python3 -m pip install {{ pydbapi_output_dir }}/hdbcli-*.tar.gz
+    {% endif %}
+    - require:
+      - nw_install_python_pip
+      - nw_extract_pydbapi_client
+
+nw_remove_pydbapi_client:
+  file.absent:
+    - name: {{ pydbapi_output_dir }}
+    - onchanges:
+      - nw_extract_pydbapi_client
+{% endif %}
+{% endfor %}

--- a/netweaver/setup/install_pydbapi.sls
+++ b/netweaver/setup/install_pydbapi.sls
@@ -33,9 +33,16 @@ nw_install_pydbapi_client:
     {% else %}
     - name: /usr/bin/python3 -m pip install {{ pydbapi_output_dir }}/hdbcli-*.tar.gz
     {% endif %}
+    - reload_modules: true
     - require:
       - nw_install_python_pip
       - nw_extract_pydbapi_client
+
+nw_reload_hdb_connector:
+  module.run:
+    - hana.reload_hdb_connector:
+    - require:
+      - nw_install_pydbapi_client
 
 nw_remove_pydbapi_client:
   file.absent:

--- a/netweaver/setup/packages.sls
+++ b/netweaver/setup/packages.sls
@@ -31,14 +31,11 @@ install_netweaver_packages:
 # Install shaptools depending on the os and python version
 install_netweaver_shaptools:
   pkg.installed:
-    - pkgs:
-      {% if grains['pythonversion'][0] == 2 %}
-      - python-PyHDB
-      - python-shaptools
-      {% else %}
-      - python3-PyHDB
-      - python3-shaptools
-      {% endif %}
+    {% if grains['pythonversion'][0] == 2 %}
+    - name: python-shaptools
+    {% else %}
+    - name: python3-shaptools
+    {% endif %}
     - retry:
         attempts: 3
         interval: 15

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,7 +1,14 @@
+-------------------------------------------------------------------
+Fri Mar 20 13:14:30 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.2.9
+  * Install pydbapi package to connect to the HANA database
+
+-------------------------------------------------------------------
 Thu Mar 17 12:24:56 UTC 2020 - Dario Maiocchi <dmaiocchi@suse.com>
--  Version 0.2.8
-   * Fix non-unique ID name error for monitoring.sls state
-   * Manage properly multiple exporters execution in the same host
+- Version 0.2.8
+  * Fix non-unique ID name error for monitoring.sls state
+  * Manage properly multiple exporters execution in the same host
     update spec
 
 -------------------------------------------------------------------

--- a/sapnwbootstrap-formula.spec
+++ b/sapnwbootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           sapnwbootstrap-formula
-Version:        0.2.7
+Version:        0.2.9
 Release:        0
 Summary:        SAP Netweaver platform deployment formula
 License:        Apache-2.0


### PR DESCRIPTION
Until now, we were using PyHDB to connect to the HANA database during the installation. PyHDB is not an official package. SAP provides the official python SAP Client package, that is needed to install the DB, PAS and AAS instances.
Taking advantage that this software is mandatory, this change extracts and install the python api.