### PR TITLE
Make it optional to install netweaver required packages

### DIFF
--- a/netweaver/defaults.yaml
+++ b/netweaver/defaults.yaml
@@ -1,4 +1,5 @@
 netweaver:
+  install_packages: true
   clean_nfs: True
   installation_folder: /tmp/swpm_unattended
   swpm_extract_dir: /sapmedia/NW/SWPM

--- a/netweaver/setup/init.sls
+++ b/netweaver/setup/init.sls
@@ -1,5 +1,9 @@
+{%- from "netweaver/map.jinja" import netweaver with context -%}
+
 include:
+{% if netweaver.install_packages is sameas true %}
   - netweaver.setup.packages
+{% endif %}
   - netweaver.setup.install_pydbapi
   - netweaver.setup.shared_disk
   - netweaver.setup.virtual_addresses

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,8 @@
 netweaver:
+  # optional: Install required packages to install SAP Netweaver (true by default)
+  # If set to false, these packages must be installed before the formula execution manually
+  # install_packages: true
+
   virtual_addresses:
     192.168.201.111: hacert01
     192.168.201.112: hacert02

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -2,8 +2,7 @@
 Wed Apr 22 19:17:03 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version 0.4.1
-  * Make it optional to install netweaver required packages 
-    in order to support qa mode
+  * Make it optional to install netweaver required packages
 
 -------------------------------------------------------------------
 Tue Apr 21 16:25:44 UTC 2020 - Stefano Torresi <stefano.torresi@suse.com>

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 22 19:17:03 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Version 0.4.1
+  * Make it optional to install netweaver required packages 
+    in order to support qa mode
+
+-------------------------------------------------------------------
 Tue Apr 21 16:25:44 UTC 2020 - Stefano Torresi <stefano.torresi@suse.com>
 
 - Version 0.4.0

--- a/sapnwbootstrap-formula.spec
+++ b/sapnwbootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           sapnwbootstrap-formula
-Version:        0.4.0
+Version:        0.4.1
 Release:        0
 Summary:        SAP Netweaver platform deployment formula
 License:        Apache-2.0


### PR DESCRIPTION
The netweaver formula should also have the feature of netweaver required packages to be installed optionally.

As discussed in https://github.com/SUSE/ha-sap-terraform-deployments/pull/444 this option is also required for `qa_mode` which does not require these packages to be installed always.
I have set the default option value to `true` for installing packages.