### PR TITLE
Fix shared disk usage in non HA environments

### DIFF
--- a/netweaver/setup/mount.sls
+++ b/netweaver/setup/mount.sls
@@ -7,6 +7,13 @@
 
 {% if node.sap_instance.lower() in ['ascs', 'ers'] %}
 
+create_folder_{{ node.sap_instance.lower() }}_{{ instance_name }}:
+  file.directory:
+    - name: /usr/sap/{{ node.sid.upper() }}/{{ node.sap_instance.upper() }}{{ instance }}
+
+# HA scenario where ASCS and ERS must share a disk to start/stop the processes as cluster
+{% if node.shared_disk_dev is defined %}
+
 {% if ':' in node.shared_disk_dev %} # This means that the device is a nfs share
 {% set device = node.shared_disk_dev %}
 {% set fstype = netweaver.nfs_version %}
@@ -36,6 +43,7 @@ create_folder_{{ shared_node.sap_instance.lower() }}_{{ shared_instance_name }}:
     - name: /usr/sap/{{ shared_node.sid.upper() }}/{{ shared_node.sap_instance.upper() }}{{ shared_instance }}
 
 {% endfor %}
+{% endif %}
 
 {% elif node.sap_instance.lower() in ['pas', 'aas'] %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -77,13 +77,15 @@ netweaver:
   # Just put the product id ommiting the initial part like NW_ABAP_ASCS, NW_ERS, etc
   # Examples
   product_id: NW750.HDB.ABAPHA
+  # For non HA environments
+  #product_id: NW750.HDB.ABAP
+  # For HA S4/HANA
   #product_id: S4HANA1709.CORE.HDB.ABAPHA
 
   # optional: enable sap_host_exporter (disabled by default)
   # the exporter will be installed and configured in all the nodes if it is enabled
-  sap_host_exporter: 
+  sap_host_exporter:
     enabled: false
-   
 
   nodes:
     - host: hacert01
@@ -94,12 +96,17 @@ netweaver:
       instance: 00
       root_user: root
       root_password: linux
+      # Set the shared disk used in HA environments. Skip this parameter in non HA environments
       shared_disk_dev: /dev/sbd
+      # Or if a nfs share is used to manage the HA mounting point, like in the cloud providers
+      #shared_disk_dev: your_nfs_share_SID_folder/ASCS
+      # Init the shared disk. Only used if a shared disk is provided, not in nfs share cases
       init_shared_disk: True
-      sap_instance: ascs
       # Set an specific product id. In this case the initial part of the code is accepted too, even though it's recommend to use the 1st example option
       product_id: NW750.HDB.ABAPHA
+      #product_id: NW750.HDB.ABAP
       #product_id: NW_ABAP_ASCS:S4HANA1709.CORE.HDB.ABAPHA
+      sap_instance: ascs
 
     - host: hacert02
       virtual_host: sapha1er
@@ -108,7 +115,10 @@ netweaver:
       saptune_solution: 'MAXDB'
       root_user: root
       root_password: linux
+      # Set the shared disk used in HA environments. Skip this parameter in non HA environments
       shared_disk_dev: /dev/sbd
+      # If a nfs share is used to manage the HA mounting point, like in the cloud
+      #shared_disk_dev: your_nfs_share_SID_folder/ERS
       sap_instance: ers
 
     - host: hacert03

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 12 13:55:55 UTC 2020 - Xabier Arbulu Insausti <xarbulu@localhost>
+
+- Version 0.4.2
+  * Fix the shared disk usage in non HA environments 
+
+-------------------------------------------------------------------
 Wed Apr 22 19:17:03 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version 0.4.1

--- a/sapnwbootstrap-formula.spec
+++ b/sapnwbootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           sapnwbootstrap-formula
-Version:        0.4.1
+Version:        0.4.2
 Release:        0
 Summary:        SAP Netweaver platform deployment formula
 License:        Apache-2.0


### PR DESCRIPTION
`shared_disk` usage is not needed in non HA environments (there is not any need to mount the ASCS data in a shared disk).

This changes the need to have this parameter yes or yes, now it can be ommited for non HA environments.

I have added some more comments in the pillar file to show how it works