### PR TITLE
Use gcp-vcp-move-ip route names properly

### DIFF
--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,13 +1,20 @@
 -------------------------------------------------------------------
+Mon May 18 15:02:26 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.4.4
+  * Use gcp-vpc-move-route properly using independent route names
+  for ASCS and ERS instances
+
 Fri May 15 09:31:34 UTC 2020 - Stefano Torresi <stefano.torresi@suse.com>
 
-- Update monitoring settings 
+- Version 0.4.3
+  * Update monitoring settings
 
 -------------------------------------------------------------------
 Tue May 12 13:55:55 UTC 2020 - Xabier Arbulu Insausti <xarbulu@localhost>
 
 - Version 0.4.2
-  * Fix the shared disk usage in non HA environments 
+  * Fix the shared disk usage in non HA environments
 
 -------------------------------------------------------------------
 Wed Apr 22 19:17:03 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
@@ -33,7 +40,7 @@ Tue Apr 14 13:38:47 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.2.11
   * Update anyting socat resource by azure-lb as recommended in
-  the updated best practices guide 
+  the updated best practices guide
 
 -------------------------------------------------------------------
 Fri Mar 27 18:23:40 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>

--- a/sapnwbootstrap-formula.spec
+++ b/sapnwbootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           sapnwbootstrap-formula
-Version:        0.4.3
+Version:        0.4.4
 Release:        0
 Summary:        SAP Netweaver platform deployment formula
 License:        Apache-2.0

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -59,13 +59,13 @@ primitive rsc_gcp_stonith_{{ sid }}_{{ grains['host'] }} stonith:fence_gce \
     meta target-role=Started
 
 primitive rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} ocf:heartbeat:gcp-vpc-move-route \
-    params ip={{ data.ascs_ip_address }} vpc_network={{ data.vpc_network_name }} route_name={{ data.route_table }} \
+    params ip={{ data.ascs_ip_address }} vpc_network={{ data.vpc_network_name }} route_name={{ data.ascs_route_name|default("nw-ascs-"~sid~"-route") }} \
     op start interval=0 timeout=180 \
     op stop interval=0 timeout=180 \
     op monitor interval=60 timeout=60
 
 primitive rsc_ip_{{ sid }}_ERS{{ ers_instance }} ocf:heartbeat:gcp-vpc-move-route \
-    params ip={{ data.ers_ip_address }} vpc_network={{ data.vpc_network_name }} route_name={{ data.route_table }} \
+    params ip={{ data.ers_ip_address }} vpc_network={{ data.vpc_network_name }} route_name={{ data.ers_route_name|default("nw-ers-"~sid~"-route") }} \
     op start interval=0 timeout=180 \
     op stop interval=0 timeout=180 \
     op monitor interval=60 timeout=60


### PR DESCRIPTION
I found out that we were using the route names incorrectly, using only 1 route for both ASCS and ERS. In my last try crmsh complained with:
```
xarbulu-netweaver01:~ # /usr/sbin/crm configure load update /tmp/cluster.config
WARNING: Resources rsc_ip_HA1_ASCS00,rsc_ip_HA1_ERS10 violate uniqueness for parameter "route_name": "xarbulu-nw-route"
Do you still want to commit (y/n)? n
```

I realized that it makes a total sense, and we need to provide 2 route names.