### PR TITLE
Feature/native fencing

### DIFF
--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,14 +1,21 @@
 -------------------------------------------------------------------
+Thu Oct  1 07:05:30 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Set the native fence mechanism usage for CSP as optional
+- Add instance name sufix to socat resources
+- Remove meta resource-stickness to the ERS resources group
+
+-------------------------------------------------------------------
 Thu Sep 24 12:43:47 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Implement the differences between ENSA1 and ENSA2 versions
-- Add the keepalive configuration changes 
+- Add the keepalive configuration changes
 
 -------------------------------------------------------------------
 Thu Aug 20 02:19:18 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version 0.5.1
-  * Add pillar.example to package 
+  * Add pillar.example to package
   (bsc#1174994, jsc#SLE-4047)
 
 -------------------------------------------------------------------

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -176,14 +176,13 @@ primitive rsc_sap_{{ sid }}_ERS{{ ers_instance }} SAPInstance \
 group grp_{{ sid }}_ERS{{ ers_instance }} \
   rsc_ip_{{ sid }}_ERS{{ ers_instance }} \
   rsc_fs_{{ sid }}_ERS{{ ers_instance }} \
-  rsc_sap_{{ sid }}_ERS{{ ers_instance }} \
-  {%- if cloud_provider == "microsoft-azure" %}
-  rsc_socat_{{ sid }}_ERS \
+  rsc_sap_{{ sid }}_ERS{{ ers_instance }}
+  {%- if cloud_provider == "microsoft-azure" %} \
+  rsc_socat_{{ sid }}_ERS
   {%- endif %}
-  {%- if monitoring_enabled -%}
-  rsc_exporter_{{ sid }}_ERS{{ ers_instance }} \
+  {%- if monitoring_enabled %} \
+  rsc_exporter_{{ sid }}_ERS{{ ers_instance }}
   {%- endif %}
-  meta resource-stickiness=3000
 
 colocation col_sap_{{ sid }}_no_both -5000: grp_{{ sid }}_ERS{{ ers_instance }} grp_{{ sid }}_ASCS{{ ascs_instance }}
 {%- if ensa_version == 1 %}

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -90,11 +90,11 @@ primitive rsc_ip_{{ sid }}_ERS{{ ers_instance }} ocf:heartbeat:gcp-vpc-move-rout
 
 {%- if cloud_provider == "microsoft-azure" %}
 
-primitive rsc_socat_{{ sid }}_ASCS azure-lb \
+primitive rsc_socat_{{ sid }}_ASCS{{ ascs_instance }} azure-lb \
   params port=620{{ ascs_instance }} \
   op monitor timeout=20s interval=10 depth=0
 
-primitive rsc_socat_{{ sid }}_ERS azure-lb \
+primitive rsc_socat_{{ sid }}_ERS{{ ers_instance }} azure-lb \
   params port=621{{ ers_instance }} \
   op monitor timeout=20s interval=10 depth=0
 

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -13,6 +13,7 @@
 {%- set ascs_virtual_host = data.ascs_virtual_host %}
 {%- set ers_virtual_host = data.ers_virtual_host %}
 {%- set monitoring_enabled = pillar.cluster.monitoring_enabled|default(False) %}
+{%- set native_fencing = data.native_fencing|default(True) %}
 
 {%- if data.ensa_version is defined %}
 {%- set ensa_version = data.ensa_version|int %}
@@ -28,11 +29,6 @@
 
 {%- if cloud_provider == "amazon-web-services" %}
 
-property cib-bootstrap-options: \
-  stonith-enabled="true" \
-  stonith-action="off" \
-  stonith-timeout="600s"
-
 rsc_defaults rsc-options: \
 	resource-stickiness=1 \
 	migration-threshold=3
@@ -41,12 +37,19 @@ op_defaults op-options: \
 	timeout=600 \
 	record-pending=true
 
+{%- if native_fencing %}
+property cib-bootstrap-options: \
+  stonith-enabled="true" \
+  stonith-action="off" \
+  stonith-timeout="600s"
+
 primitive res_aws_stonith_{{ sid }} stonith:external/ec2 \
   params tag={{ data.instance_tag }} profile={{ data.cluster_profile}} \
   op start interval=0 timeout=180 \
   op stop interval=0 timeout=180 \
   op monitor interval=120 timeout=60 \
   meta target-role=Started
+{%- endif %}
 
 primitive rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} ocf:suse:aws-vpc-move-ip \
   params ip={{ ascs_ip_address }} routing_table={{ data.route_table}} \
@@ -64,10 +67,12 @@ primitive rsc_ip_{{ sid }}_ERS{{ ers_instance }} ocf:suse:aws-vpc-move-ip \
 
 {%- elif cloud_provider == "google-cloud-platform" %}
 
+{%- if native_fencing %}
 # This stonith resource will be duplicated for each node in the cluster
 primitive rsc_gcp_stonith_{{ sid }}_{{ grains['host'] }} stonith:fence_gce \
     params plug={{ grains['gcp_instance_name'] }} pcmk_host_map="{{ grains['host'] }}:{{ grains['gcp_instance_name'] }}" \
     meta target-role=Started
+{%- endif %}
 
 primitive rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} ocf:heartbeat:gcp-vpc-move-route \
     params ip={{ data.ascs_ip_address }} vpc_network={{ data.vpc_network_name }} route_name={{ data.ascs_route_name|default("nw-ascs-"~sid~"-route") }} \


### PR DESCRIPTION
Enable native fencing optionally.
At some cases, sbd is used as fencing mechanism, and for those cases, we need to disable the native fencing mechanism.
By now, we only have it for gcp and aws (for azure will be the same).

Besides that, I have added the `instance_name` sufix to the socat resources, to unify the naming

FYI: @peteratsuse