### PR TITLE
Update the default swpm media extract location

### DIFF
--- a/netweaver/defaults.yaml
+++ b/netweaver/defaults.yaml
@@ -2,7 +2,7 @@ netweaver:
   install_packages: true
   clean_nfs: True
   installation_folder: /tmp/swpm_unattended
-  nw_extract_dir: /sapmedia/NW
+  nw_extract_dir: /sapmedia_extract/NW
   additional_dvds: []
   ha_enabled: True
   nfs_version: nfs4 # Used to connect to the nfs share

--- a/pillar.example
+++ b/pillar.example
@@ -31,7 +31,7 @@ netweaver:
   # Specify the path to already extracted SWPM installer folder
   swpm_folder: your_swpm_folder_absolute_path
   # Or specify the path to the sapcar executable & SWPM installer sar archive, to extract the installer
-  # The sar archive will be extracted to a subfolder SWPM, under nw_extract_dir (optional, by default /sapmedia/NW/SWPM)
+  # The sar archive will be extracted to a subfolder SWPM, under nw_extract_dir (optional, by default /sapmedia_extract/NW/SWPM)
   # Make sure to use the latest/compatible version of sapcar executable, and that it has correct execute permissions
   sapcar_exe_file: your_sapcar_exe_file_absolute_path
   swpm_sar_file: your_swpm_sar_file_absolute_path

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Oct 14 23:40:20 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Update the default 'nw_extract_dir' SWPM media extraction location 
+
+-------------------------------------------------------------------
 Wed Oct  7 19:58:03 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version 0.5.2


### PR DESCRIPTION
Changing the Netweaver SWPM default extraction location, to avoid conflict with the ready-only sap media mount points

`/sapmedia_extract/NW`

The SWPM archive gets extracted to `/sapmedia_extract/NW/SWPM`