### PR TITLE
Feature/s4hana

### DIFF
--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 15 07:21:21 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Update the db installation template to use correctly the schema
+  names for S/4HANA 
+
+-------------------------------------------------------------------
 Thu Sep 24 12:43:47 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Implement the differences between ENSA1 and ENSA2 versions

--- a/templates/db.inifile.params.j2
+++ b/templates/db.inifile.params.j2
@@ -17,7 +17,8 @@
 # HDB_Schema_Check_Dialogs.dropSchema = false
 
 # The name of the database schema.
-{% if schema_name == 'SAPABAP1' %}
+# For S/4HANA new versions (1809 and beyond), the DB is always named `SAPHANADB` always
+{% if schema_name in ['SAPABAP1', 'SAPHANADB'] %}
 # HDB_Schema_Check_Dialogs.schemaName = {{ schema_name }}
 {% else %}
 HDB_Schema_Check_Dialogs.schemaName = {{ schema_name }}

--- a/templates/db.inifile.params.j2
+++ b/templates/db.inifile.params.j2
@@ -17,7 +17,7 @@
 # HDB_Schema_Check_Dialogs.dropSchema = false
 
 # The name of the database schema.
-# For S/4HANA new versions (1809 and beyond), the DB is always named `SAPHANADB` always
+# For S/4HANA new versions (1809 and beyond), the DB is always named `SAPHANADB`
 {% if schema_name in ['SAPABAP1', 'SAPHANADB'] %}
 # HDB_Schema_Check_Dialogs.schemaName = {{ schema_name }}
 {% else %}


### PR DESCRIPTION
Add new logic in the database installation template to work properly for S/4HANA.

During S/4HANA installation, the created schema name always is `SAPHANADB`. If you try to use any other name, the installation fails saying that this name cannot be changed.