### PR TITLE
Fix additional_dvds variable usage when salt uses python 2

### DIFF
--- a/netweaver/extract_nw_archives.sls
+++ b/netweaver/extract_nw_archives.sls
@@ -74,3 +74,5 @@ extract_sar_archive_{{ dvd }}:
 
 {%- endif %}
 {%- endfor %}
+
+{%- set additional_dvd_folders = additional_dvd_folders | tojson %}

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 19 10:59:12 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Fix additional_dvds variable usage when salt uses python 2. The
+  variable is filtered by 'tojson' option to avoid 'u' prefix in
+  lists 
+
+-------------------------------------------------------------------
 Mon Oct 19 14:54:33 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Set the native fence mechanism usage for CSP as optional


### PR DESCRIPTION
The `additional_dvds` management still fails if salt is using python 2 (what happens in SLE12).

The error is:
```OSError: [Errno 2] No such file or directory: "u'/sapmedia/NW/51050829_3'"```
The `u` character is added as prefix in the lists.

This change uses the `tojson` filter to sanitize the string

Additional info about the same issue: https://github.com/saltstack/salt/issues/47001