### PR TITLE
Start the saptune daemon service

### DIFF
--- a/netweaver/saptune.sls
+++ b/netweaver/saptune.sls
@@ -4,7 +4,14 @@
 {% set saptune_solution = node.saptune_solution|default(netweaver.saptune_solution) %}
 {% set instance = '{:0>2}'.format(node.instance) %}
 {% set name = '{}_{}'.format(node.sid, instance) %}
+
 apply_saptune_solution_{{ host }}_{{ name }}:
   saptune.solution_applied:
     - name: {{ saptune_solution }}
+
+# Start the saptune systemd service to ensure the system is well-tuned after a system reboot
+start_saptune_service_{{ host }}_{{ name }}:
+  cmd.run:
+    - name: saptune daemon start
+
 {% endfor %}

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Dec  2 18:41:35 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Start the saptune systemd service 
+
+-------------------------------------------------------------------
 Thu Nov 19 10:59:12 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Fix additional_dvds variable usage when salt uses python 2. The


### PR DESCRIPTION
Start the `saptune` daemon on netweaver nodes 'tuned.service' (in saptune version 2) and 'saptune.service' (saptune version 3).
It is needed to get the sap tuning back especially after system reboot.
I have added the saptune daemon start cmd. Tested with Netweaver deployment