### PR TITLE
Fix error about missing instance installation requisite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ sudo: required
 services:
   - docker
 
+dist: bionic
 addons:
   apt:
     sources:
-      - sourceline: 'deb http://repo.saltstack.com/apt/ubuntu/18.04/amd64/2019.2/ bionic main'
-        key_url: 'http://repo.saltstack.com/apt/ubuntu/18.04/amd64/2019.2/SALTSTACK-GPG-KEY.pub'
+      - sourceline: 'deb http://repo.saltstack.com/apt/ubuntu/18.04/amd64/3000/ bionic main'
+        key_url: 'http://repo.saltstack.com/apt/ubuntu/18.04/amd64/3000/SALTSTACK-GPG-KEY.pub'
     packages:
         - salt-common
 

--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">sapnwbootstrap-formula</param>
-    <param name="versionformat">0.6.0+git.%ct.%h</param>
+    <param name="versionformat">0.6.1+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/netweaver/monitoring.sls
+++ b/netweaver/monitoring.sls
@@ -6,7 +6,7 @@ prometheus_sap_host_exporter_pkg:
     - name: prometheus-sap_host_exporter
 
 # the sid, instance number pair of a node is unique, so we need to adapt configuration
-{% for node in netweaver.nodes if node.sap_instance != "db" %}
+{% for node in netweaver.nodes if host == node.host and node.sap_instance != "db" %}
 {% set sap_instance_nr = '{:0>2}'.format(node.instance) %}
 {% set exporter_instance = '{}_{}{}'.format(node.sid, node.sap_instance.upper(), sap_instance_nr) %}
 {% set instance_name = node.sid~'_'~sap_instance_nr %}
@@ -22,7 +22,6 @@ sap_host_exporter_configuration_{{ exporter_instance }}:
       - pkg: prometheus_sap_host_exporter_pkg
       - netweaver_install_{{ instance_name }}
 
-{% if host == node.host %}
 sap_host_exporter_service_{{ exporter_instance }}:
   service.running:
     - name: prometheus-sap_host_exporter@{{ exporter_instance }}

--- a/netweaver/monitoring.sls
+++ b/netweaver/monitoring.sls
@@ -32,5 +32,5 @@ sap_host_exporter_service_{{ exporter_instance }}:
       - file: sap_host_exporter_configuration_{{ exporter_instance }}
     - watch:
       - file: sap_host_exporter_configuration_{{ exporter_instance }}
-{% endif %}
+
 {% endfor %}

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 28 22:23:36 UTC 2021 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Version 0.6.1
+  * Fix error about missing instance installation requisite when monitoring is enabled
+  (bsc#1181541) 
+
+-------------------------------------------------------------------
 Tue Jan 19 13:39:12 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.6.0


### PR DESCRIPTION
When monitoring is enabled, one of the monitoring state `sap_host_exporter_configuration_{{ exporter_instance }}` is run for all nodes. This cause the error about some missing nw installation states which are part of requisite for the monitoring state.

I have added check for host,to make sure current node installation is checked instead of all nodes.
I have updated the formula version and created related bugzilla entry to submit to SLE.