### PR TITLE
Update PAS and AAS templates to use HANA sid and instance number

### DIFF
--- a/netweaver/install_aas.sls
+++ b/netweaver/install_aas.sls
@@ -28,6 +28,8 @@ create_aas_inifile_{{ instance_name }}:
         download_basket: {{ netweaver.sapexe_folder }}
         schema_name: {{ netweaver.schema.name|default('SAPABAP1') }}
         schema_password: {{ netweaver.schema.password }}
+        hana_host: {{ netweaver.hana.host }}
+        hana_sid: {{ netweaver.hana.sid }}
         hana_password: {{ netweaver.hana.password }}
         hana_inst: {{ hana_instance }}
 

--- a/netweaver/install_pas.sls
+++ b/netweaver/install_pas.sls
@@ -30,6 +30,8 @@ create_pas_inifile_{{ instance_name }}:
         schema_name: {{ netweaver.schema.name|default('SAPABAP1') }}
         schema_password: {{ netweaver.schema.password }}
         ascs_virtual_hostname: {{ node.ascs_virtual_host }}
+        hana_host: {{ netweaver.hana.host }}
+        hana_sid: {{ netweaver.hana.sid }}
         hana_password: {{ netweaver.hana.password }}
         hana_inst: {{ hana_instance }}
 

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 10 16:14:24 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
+
+- Update PAS and AAS templates to use HANA sid and instance number
+  to create the configuration file 
+
+-------------------------------------------------------------------
 Thu Jan 28 22:23:36 UTC 2021 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version 0.6.1

--- a/templates/aas.inifile.params.j2
+++ b/templates/aas.inifile.params.j2
@@ -64,8 +64,20 @@ NW_GetMasterPassword.masterPwd = {{ master_password }}
 # Install the SAP HANA database client in a central or local directory. Possible values are: 'SAPCPE', 'LOCAL'
 # NW_HDB_DBClient.clientPathStrategy = LOCAL
 
+# Database host
+NW_HDB_getDBInfo.dbhost = {{ hana_host }}
+
+# Database system ID
+NW_HDB_getDBInfo.dbsid = {{ hana_sid.upper() }}
+
+# The instance number of the SAP HANA database server
+NW_HDB_getDBInfo.instanceNumber = {{ '{:0>2}'.format(hana_inst) }}
+
 # Password of user 'SYSTEM' within the 'SystemDB' tenant in an SAP HANA MultiDB server
 NW_HDB_getDBInfo.systemDbPassword = {{ hana_password }}
+
+# Password of user 'SYSTEM' inside the SAP HANA database server
+NW_HDB_getDBInfo.systemPassword = {{ hana_password }}
 
 # NW_SAPCrypto.SAPCryptoFile =
 

--- a/templates/pas.inifile.params.j2
+++ b/templates/pas.inifile.params.j2
@@ -115,8 +115,20 @@ NW_GetMasterPassword.masterPwd = {{ master_password }}
 # Install the SAP HANA database client in a central or local directory. Possible values are: 'SAPCPE', 'LOCAL'
 # NW_HDB_DBClient.clientPathStrategy = LOCAL
 
+# Database host
+NW_HDB_getDBInfo.dbhost = {{ hana_host }}
+
+# Database system ID
+NW_HDB_getDBInfo.dbsid = {{ hana_sid.upper() }}
+
+# The instance number of the SAP HANA database server
+NW_HDB_getDBInfo.instanceNumber = {{ '{:0>2}'.format(hana_inst) }}
+
 # Password of user 'SYSTEM' within the 'SystemDB' tenant in an SAP HANA MultiDB server
 NW_HDB_getDBInfo.systemDbPassword = {{ hana_password }}
+
+# Password of user 'SYSTEM' inside the SAP HANA database server
+NW_HDB_getDBInfo.systemPassword = {{ hana_password }}
 
 # Enable the instance agent (sapstartsrv) data supplier to send operating system information to the System Landscape Directory (SLD). Default is 'false'.
 # NW_SLD_Configuration.configureSld = false


### PR DESCRIPTION
Fix issue: https://github.com/SUSE/ha-sap-terraform-deployments/issues/617

For a reason I cannot understand, some deployments in some CSP (we have had this issue in GCP) need additional data in the templates to install the PAS and AAS. Fortunately, this data is already available.

The root cause of the error can be checked in `sapinst.log` and `sapinst_dev.log`, with these traces:

```
#sapints.log
ERROR 2021-02-11 08:29:13.710 (root/sapinst) id=modlib.jslib.caughtException errno=MUT-03025
Caught ESAPinstException in module call: Validator of step '|NW_ABAP_CI|ind|ind|ind|ind|0|0|NW_GetSidFromProfilesPartial|ind|ind|ind|ind|getSid|0|NW_getDBInfo|ind|ind|ind|ind|db|0|NW_HDB_getDBInfo|ind|ind|ind|ind|hdb_dbinfo|0|getDBInfo' reported an error:
Start SAPinst in interactive mode to solve this problem.

ERROR 2021-02-11 08:29:13.841 (root/sapinst) id=controller.stepExecuted errno=FCO-00011
The step getDBInfo with step key |NW_ABAP_CI|ind|ind|ind|ind|0|0|NW_GetSidFromProfilesPartial|ind|ind|ind|ind|getSid|0|NW_getDBInfo|ind|ind|ind|ind|db|0|NW_HDB_getDBInfo|ind|ind|ind|ind|hdb_dbinfo|0|getDBInfo was executed with status ERROR (Last error reported by the step: Caught ESAPinstException in module call: Validator of step '|NW_ABAP_CI|ind|ind|ind|ind|0|0|NW_GetSidFromProfilesPartial|ind|ind|ind|ind|getSid|0|NW_getDBInfo|ind|ind|ind|ind|db|0|NW_HDB_getDBInfo|ind|ind|ind|ind|hdb_dbinfo|0|getDBInfo' reported an error:
Start SAPinst in interactive mode to solve this problem).
```

```
#sapinst_dev.log
TRACE      2021-02-11 08:29:13.709 (root/sapinst) (startInstallation) [DarkModeDialog.cpp:108] DarkModeDialog::submit()
Front side checks for 'd_nw_getdbinfo_hdb' returned false:
Checking input element 'dbhost': Value '' is shorter than 1 characters.
   Checking input element 'dbsid': Value '' is shorter than 3 characters.
   Checking input element 'instanceNumber': Value '' is shorter than 2 characters.

```