### PR TITLE
Feature/make sapmnt configurable

### DIFF
--- a/netweaver/defaults.yaml
+++ b/netweaver/defaults.yaml
@@ -5,6 +5,7 @@ netweaver:
   nw_extract_dir: /sapmedia_extract/NW
   additional_dvds: []
   ha_enabled: True
+  sapmnt_path: /sapmnt
   sapmnt_inst_media: "" # NFS share to mount /sapmnt and /usr/sap/{sid}/SYS. Empty string means that folders are mounted locally
   nfs_version: nfs4 # Used to connect to the nfs share
   nfs_options: defaults

--- a/netweaver/defaults.yaml
+++ b/netweaver/defaults.yaml
@@ -5,6 +5,7 @@ netweaver:
   nw_extract_dir: /sapmedia_extract/NW
   additional_dvds: []
   ha_enabled: True
+  sapmnt_inst_media: "" # NFS share to mount /sapmnt and /usr/sap/{sid}/SYS. Empty string means that folders are mounted locally
   nfs_version: nfs4 # Used to connect to the nfs share
   nfs_options: defaults
   # Set this entry to false to disable creating swap

--- a/netweaver/install_aas.sls
+++ b/netweaver/install_aas.sls
@@ -32,6 +32,7 @@ create_aas_inifile_{{ instance_name }}:
         hana_sid: {{ netweaver.hana.sid }}
         hana_password: {{ netweaver.hana.password }}
         hana_inst: {{ hana_instance }}
+        sapmnt_path: {{ netweaver.sapmnt_path }}
 
 {% if node.extra_parameters is defined %}
 update_aas_inifile_{{ instance_name }}:
@@ -45,7 +46,7 @@ update_aas_inifile_{{ instance_name }}:
 
 check_sapprofile_directory_exists_{{ instance_name }}:
   file.exists:
-    - name: /sapmnt/{{ node.sid.upper() }}/profile
+    - name: {{ netweaver.sapmnt_path }}/{{ node.sid.upper() }}/profile
     - retry:
         attempts: 70
         interval: 30

--- a/netweaver/install_ascs.sls
+++ b/netweaver/install_ascs.sls
@@ -26,6 +26,7 @@ create_ascs_inifile_{{ instance_name }}:
         instance: {{ instance }}
         virtual_hostname: {{ node.virtual_host }}
         download_basket: {{ netweaver.sapexe_folder }}
+        sapmnt_path: {{ netweaver.sapmnt_path }}
 
 {% if node.extra_parameters is defined %}
 update_ascs_inifile_{{ instance_name }}:

--- a/netweaver/install_db.sls
+++ b/netweaver/install_db.sls
@@ -31,6 +31,7 @@ create_db_inifile_{{ instance_name }}:
         hana_sid: {{ netweaver.hana.sid }}
         hana_password: {{ netweaver.hana.password }}
         hana_inst: {{ hana_instance }}
+        sapmnt_path: {{ netweaver.sapmnt_path }}
 
 {% if node.extra_parameters is defined %}
 update_db_inifile_{{ instance_name }}:
@@ -44,7 +45,7 @@ update_db_inifile_{{ instance_name }}:
 
 check_sapprofile_directory_exists_{{ instance_name }}:
   file.exists:
-    - name: /sapmnt/{{ node.sid.upper() }}/profile
+    - name: {{ netweaver.sapmnt_path }}/{{ node.sid.upper() }}/profile
     - retry:
         attempts: 70
         interval: 30

--- a/netweaver/install_ers.sls
+++ b/netweaver/install_ers.sls
@@ -26,6 +26,7 @@ create_ers_inifile_{{ instance_name }}:
         instance: {{ instance }}
         virtual_hostname: {{ node.virtual_host }}
         download_basket: {{ netweaver.sapexe_folder }}
+        sapmnt_path: {{ netweaver.sapmnt_path }}
 
 {% if node.extra_parameters is defined %}
 update_ers_inifile_{{ instance_name }}:
@@ -39,7 +40,7 @@ update_ers_inifile_{{ instance_name }}:
 
 check_sapprofile_directory_exists_{{ instance_name }}:
   file.exists:
-    - name: /sapmnt/{{ node.sid.upper() }}/profile
+    - name: {{ netweaver.sapmnt_path }}/{{ node.sid.upper() }}/profile
     - retry:
         attempts: 70
         interval: 30

--- a/netweaver/install_pas.sls
+++ b/netweaver/install_pas.sls
@@ -34,6 +34,7 @@ create_pas_inifile_{{ instance_name }}:
         hana_sid: {{ netweaver.hana.sid }}
         hana_password: {{ netweaver.hana.password }}
         hana_inst: {{ hana_instance }}
+        sapmnt_path: {{ netweaver.sapmnt_path }}
 
 {% if node.extra_parameters is defined %}
 update_pas_inifile_{{ instance_name }}:
@@ -47,7 +48,7 @@ update_pas_inifile_{{ instance_name }}:
 
 check_sapprofile_directory_exists_{{ instance_name }}:
   file.exists:
-    - name: /sapmnt/{{ node.sid.upper() }}/profile
+    - name: {{ netweaver.sapmnt_path }}/{{ node.sid.upper() }}/profile
     - retry:
         attempts: 70
         interval: 30

--- a/netweaver/setup/sap_nfs.sls
+++ b/netweaver/setup/sap_nfs.sls
@@ -1,6 +1,15 @@
 {%- from "netweaver/map.jinja" import netweaver with context -%}
 {% set host = grains['host'] %}
 
+{% for node in netweaver.nodes if host == node.host %}
+
+{% set instance = '{:0>2}'.format(node.instance) %}
+{% set instance_name =  node.sid~'_'~instance %}
+
+# Provided sapmnt_inst_media is a NFS share path
+{% if ':' in netweaver.sapmnt_inst_media %}
+
+{% if loop.first %}
 mount_sapmnt:
   mount.mounted:
     - name: /sapmnt
@@ -10,11 +19,7 @@ mount_sapmnt:
       - {{ netweaver.nfs_options }}
     - mkmnt: True
     - persist: True
-
-{% for node in netweaver.nodes if host == node.host %}
-
-{% set instance = '{:0>2}'.format(node.instance) %}
-{% set instance_name =  node.sid~'_'~instance %}
+{% endif %}
 
 mount_usersapsys_{{ instance_name }}:
   mount.mounted:
@@ -26,9 +31,7 @@ mount_usersapsys_{{ instance_name }}:
     - mkmnt: True
     - persist: True
 
-
 {% if netweaver.clean_nfs and node.sap_instance == 'ascs' %}
-
 clean_nfs_sapmnt_{{ instance_name }}:
   file.absent:
     - name: /sapmnt/{{ node.sid.upper() }}
@@ -37,7 +40,21 @@ clean_nfs_usr_{{ instance_name }}:
   file.directory:
     - name: /usr/sap/{{ node.sid.upper() }}/SYS
     - clean: True
-
 {% endif %}
 
+# Create the `/sapmnt` and `/usr/sap/{sid}/SYS` locally
+{% else %}
+{% if loop.first %}
+create_folder_sapmnt:
+  file.directory:
+    - name: /sapmnt
+    - makedirs: True
+{% endif %}
+
+create_folder_sap_sys_{{ instance_name }}:
+  file.directory:
+    - name: /usr/sap/{{ node.sid.upper() }}/SYS
+    - makedirs: True
+
+{% endif %}
 {% endfor %}

--- a/netweaver/setup/sap_nfs.sls
+++ b/netweaver/setup/sap_nfs.sls
@@ -12,7 +12,7 @@
 {% if loop.first %}
 mount_sapmnt:
   mount.mounted:
-    - name: /sapmnt
+    - name: {{ netweaver.sapmnt_path }}
     - device: {{ netweaver.sapmnt_inst_media }}/sapmnt
     - fstype: {{ netweaver.nfs_version }}
     - opts:
@@ -34,7 +34,7 @@ mount_usersapsys_{{ instance_name }}:
 {% if netweaver.clean_nfs and node.sap_instance == 'ascs' %}
 clean_nfs_sapmnt_{{ instance_name }}:
   file.absent:
-    - name: /sapmnt/{{ node.sid.upper() }}
+    - name: {{ netweaver.sapmnt_path }}/{{ node.sid.upper() }}
 
 clean_nfs_usr_{{ instance_name }}:
   file.directory:
@@ -47,7 +47,7 @@ clean_nfs_usr_{{ instance_name }}:
 {% if loop.first %}
 create_folder_sapmnt:
   file.directory:
-    - name: /sapmnt
+    - name: {{ netweaver.sapmnt_path }}
     - makedirs: True
 {% endif %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -24,10 +24,20 @@ netweaver:
   sap_adm_password: your_sapadm_password
   # Master password is used for all the SAP users that are created
   master_password: your_password
-  # Clean /sapmnt/{sid} and /usr/sap/{sid}/SYS content. It will only work if ASCS node is defined.
-  # True by default
-  clean_nfs: True
+
+  # Define NFS share where `sapmnt` and `SYS` folder will be mounted. This NFS share must already have
+  # the `sapmnt` and `usrsapsys` folders
+  # If it is not used or empty string is set, the `sapmnt` and `SYS` folder are created locally
   sapmnt_inst_media: your_nfs_share_SID_folder
+  # Clean /sapmnt/{sid} and /usr/sap/{sid}/SYS content. It will only work if ASCS node is defined.
+  # True by default. It only works if a NFS share is defined in `sapmnt_inst_media`
+  clean_nfs: True
+  # Used to connect to the nfs share
+  nfs_version: nfs4
+  nfs_options: defaults
+  # Use the next options for AWS for example
+  # nfs_options: rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2
+
   # Specify the path to already extracted SWPM installer folder
   swpm_folder: your_swpm_folder_absolute_path
   # Or specify the path to the sapcar executable & SWPM installer sar archive, to extract the installer
@@ -48,19 +58,14 @@ netweaver:
     - /sapmedia/NW/51050829_3.ZIP
     - /tmp/sap_media/51050818_part1.EXE
     - /tmp/sapmedia/IMDB_SERVER.SAR
+
   # Enable operations in ASCS and ERS to set HA environment correctly (HA cluster is not installed)
   ha_enabled: True
-
-  # Used to connect to the nfs share
-  nfs_version: nfs4
-  nfs_options: defaults
-  # Use the next options for AWS for example
-  # nfs_options: rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2
 
   # syctl options. Some system options must be update for optimal usage, like tcp keepalive parameter
   # sysctl values based on:
   # https://launchpad.support.sap.com/#/notes/1410736
-  # https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse#2d6008b0-685d-426c-b59e-6cd281fd45d7  
+  # https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse#2d6008b0-685d-426c-b59e-6cd281fd45d7
   # Do not touch if not sure about the changes
   #sysctl_values:
   #  net.ipv4.tcp_keepalive_time: 300

--- a/pillar.example
+++ b/pillar.example
@@ -25,6 +25,10 @@ netweaver:
   # Master password is used for all the SAP users that are created
   master_password: your_password
 
+  # Local path where sapmnt data is stored. This is a local path. This folder can be mounted in a NFS share
+  # using `sapmnt_inst_media`
+  # /sapmnt by default
+  sapmnt_path: /sapmnt
   # Define NFS share where `sapmnt` and `SYS` folder will be mounted. This NFS share must already have
   # the `sapmnt` and `usrsapsys` folders
   # If it is not used or empty string is set, the `sapmnt` and `SYS` folder are created locally

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 15 12:34:27 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
+
+- Give the option to mount /sapmnt folder locally without using
+  a NFS share 
+
+-------------------------------------------------------------------
 Wed Feb 10 16:14:24 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Update PAS and AAS templates to use HANA sid and instance number

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -2,20 +2,21 @@
 Mon Feb 15 12:34:27 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Give the option to mount /sapmnt folder locally without using
-  a NFS share 
+  a NFS share
+- Make /sapmnt path configurable using `sapmnt_path` pillar variable
 
 -------------------------------------------------------------------
 Wed Feb 10 16:14:24 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Update PAS and AAS templates to use HANA sid and instance number
-  to create the configuration file 
+  to create the configuration file
 
 -------------------------------------------------------------------
 Thu Jan 28 22:23:36 UTC 2021 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version 0.6.1
   * Fix error about missing instance installation requisite when monitoring is enabled
-  (bsc#1181541) 
+  (bsc#1181541)
 
 -------------------------------------------------------------------
 Tue Jan 19 13:39:12 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>

--- a/templates/aas.inifile.params.j2
+++ b/templates/aas.inifile.params.j2
@@ -103,7 +103,7 @@ NW_getLoadType.loadType = SAP
 # NW_getUnicode.isUnicode =
 
 # Provide  'profile' directory of SAP Netweaver-based system.
-NW_readProfileDir.profileDir = /sapmnt/{{ sid.upper() }}/profile/
+NW_readProfileDir.profileDir = {{ sapmnt_path }}/{{ sid.upper() }}/profile/
 
 # Windows only: The drive to use
 # NW_readProfileDir.sapdrive =

--- a/templates/ascs.inifile.params.j2
+++ b/templates/ascs.inifile.params.j2
@@ -26,7 +26,7 @@ NW_GetMasterPassword.masterPwd = {{ master_password }}
 # NW_GetSidNoProfiles.sapdrive =
 
 # Unix only: The SAP mount directory path. Default value is '/sapmnt'.
-# NW_GetSidNoProfiles.sapmnt = /sapmnt
+NW_GetSidNoProfiles.sapmnt = {{ sapmnt_path }}
 
 # The SAP system ID <SAPSID> of the system to be installed
 NW_GetSidNoProfiles.sid = {{ sid }}

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -14,6 +14,7 @@
 {%- set ers_virtual_host = data.ers_virtual_host %}
 {%- set monitoring_enabled = pillar.cluster.monitoring_enabled|default(False) %}
 {%- set native_fencing = data.native_fencing|default(True) %}
+{%- set sapmnt_path = data.sapmnt_path|default('/sapmnt') %}
 
 {%- if data.ensa_version is defined %}
 {%- set ensa_version = data.ensa_version|int %}
@@ -141,7 +142,7 @@ primitive rsc_sap_{{ sid }}_ASCS{{ ascs_instance }} SAPInstance \
   operations $id=rsc_sap_{{ sid }}_ASCS{{ ascs_instance }}-operations \
   op monitor interval=120 timeout=60 on_fail=restart \
   params InstanceName={{ sid }}_ASCS{{ ascs_instance }}_{{ ascs_virtual_host }} \
-     START_PROFILE="/sapmnt/{{ sid }}/profile/{{ sid }}_ASCS{{ ascs_instance }}_{{ ascs_virtual_host }}" \
+     START_PROFILE="{{ sapmnt_path }}/{{ sid }}/profile/{{ sid }}_ASCS{{ ascs_instance }}_{{ ascs_virtual_host }}" \
      AUTOMATIC_RECOVER=false \
   meta resource-stickiness=5000 {% if ensa_version == 1 %}failure-timeout=60 migration-threshold=1 priority=10{%- endif %}
 
@@ -170,7 +171,7 @@ primitive rsc_sap_{{ sid }}_ERS{{ ers_instance }} SAPInstance \
   operations $id=rsc_sap_{{ sid }}_ERS{{ ers_instance }}-operations \
   op monitor interval=120 timeout=60 on_fail=restart \
   params InstanceName={{ sid }}_ERS{{ ers_instance }}_{{ ers_virtual_host }} \
-        START_PROFILE="/sapmnt/{{ sid }}/profile/{{ sid }}_ERS{{ ers_instance }}_{{ ers_virtual_host }}" \
+        START_PROFILE="{{ sapmnt_path }}/{{ sid }}/profile/{{ sid }}_ERS{{ ers_instance }}_{{ ers_virtual_host }}" \
         AUTOMATIC_RECOVER=false IS_ERS=true {% if ensa_version == 1 %}meta priority=1000{%- endif %}
 
 group grp_{{ sid }}_ERS{{ ers_instance }} \

--- a/templates/db.inifile.params.j2
+++ b/templates/db.inifile.params.j2
@@ -145,7 +145,7 @@ NW_getLoadType.loadType = SAP
 # NW_getUnicode.isUnicode =
 
 # Provide  'profile' directory of SAP Netweaver-based system.
-NW_readProfileDir.profileDir = /sapmnt/{{ sid.upper() }}/profile/
+NW_readProfileDir.profileDir = {{ sapmnt_path }}/{{ sid.upper() }}/profile/
 
 # Enter the path of the existing 'profile' directory.
 # NW_readProfileDir.profilesAvailable = true

--- a/templates/ers.inifile.params.j2
+++ b/templates/ers.inifile.params.j2
@@ -35,7 +35,7 @@ NW_getFQDN.setFQDN = false
 # NW_getUnicode.isUnicode =
 
 # Provide  'profile' directory of SAP Netweaver-based system.
-NW_readProfileDir.profileDir = /sapmnt/{{ sid.upper() }}/profile/
+NW_readProfileDir.profileDir = {{ sapmnt_path }}/{{ sid.upper() }}/profile/
 
 # Windows only: The drive to use
 # NW_readProfileDir.sapdrive =

--- a/templates/pas.inifile.params.j2
+++ b/templates/pas.inifile.params.j2
@@ -170,7 +170,7 @@ NW_getLoadType.loadType = SAP
 # NW_getUnicode.isUnicode =
 
 # Provide  'profile' directory of SAP Netweaver-based system.
-NW_readProfileDir.profileDir = /sapmnt/{{ sid.upper() }}/profile/
+NW_readProfileDir.profileDir = {{ sapmnt_path }}/{{ sid.upper() }}/profile/
 
 # Windows only: The drive to use
 # NW_readProfileDir.sapdrive =


### PR DESCRIPTION
Fix for: https://github.com/SUSE/sapnwbootstrap-formula/issues/74

2 things implemented:
1. Install `/sapmnt` locally instead of a NFS server. This can be used in simple deployments where ASCS and PAS are in the same machine and we don't have any HA capability. This is achieved using the `sap_inst_media`. If not used or set to empty string the local option is used. Otherwise it will work as before connecting to a NFS share
2. Provide the way to configure the `sapmnt` folder. By default is uses `/sapmnt` (which is the default value used by SAP). This option can be configured with the `sapmnt_path` pillar option