### PR TITLE
Set permanentnly the virtual addreses for non HA scenarios

### DIFF
--- a/netweaver/ha_cluster.sls
+++ b/netweaver/ha_cluster.sls
@@ -7,6 +7,17 @@
 {% set instance_name = node.sid~'_'~instance %}
 {% set instance_folder = node.sap_instance.upper()~instance %}
 {% set profile_file = '/usr/sap/'~node.sid.upper()~'/SYS/profile/'~node.sid.upper()~'_'~instance_folder~'_'~node.virtual_host %}
+{% set virtual_host_interface = node.virtual_host_interface|default('eth0') %}
+{% set ifcfg_file = '/etc/sysconfig/network/ifcfg-'~virtual_host_interface %}
+
+{% for virtual_ip, hostname in netweaver.virtual_addresses.items() if hostname == node.virtual_host %}
+# Remove permanent ip address as the element is managed by the cluster
+remove_permanent_ipaddr_{{ instance_name }}:
+  file.line:
+    - name: {{ ifcfg_file }}
+    - match: {{ virtual_ip }}
+    - mode: delete
+{% endfor %}
 
 install_suse_connector:
   pkg.installed:

--- a/netweaver/setup/virtual_addresses.sls
+++ b/netweaver/setup/virtual_addresses.sls
@@ -1,4 +1,5 @@
 {%- from "netweaver/map.jinja" import netweaver with context -%}
+{%- set host = grains['host'] %}
 
 {% for ip_address, hostname in netweaver.virtual_addresses.items() %}
 {{ hostname }}:
@@ -6,4 +7,41 @@
     - ip: {{ ip_address }}
     - names:
       - {{ hostname }}
+{% endfor %}
+
+
+{% for node in netweaver.nodes if node.host == host %}
+# Set the virtual ip addresses permanently
+{% set instance = '{:0>2}'.format(node.instance) %}
+{% set instance_name = node.sid~'_'~instance %}
+{% set virtual_host_interface = node.virtual_host_interface|default('eth0') %}
+{% set ifcfg_file = '/etc/sysconfig/network/ifcfg-'~virtual_host_interface %}
+{% set iddr_count = salt['cmd.run']('cat '~ifcfg_file~' | grep -c ^IPADDR || true', python_shell=true)|int %}
+
+{% if loop.first %}
+add_start_mode_{{ virtual_host_interface }}:
+  file.append:
+    - name: {{ ifcfg_file }}
+    - text: STARTMODE=onboot
+    - unless:
+      - cat {{ ifcfg_file }} | grep '^STARTMODE='
+
+add_boot_proto_{{ virtual_host_interface }}:
+  file.append:
+    - name: {{ ifcfg_file }}
+    - text: BOOTPROTO=static
+    - unless:
+      - cat {{ ifcfg_file }} | grep '^BOOTPROTO='
+{% endif %}
+
+{% set current_iddr = loop.index0+iddr_count %}
+{% for virtual_ip, hostname in netweaver.virtual_addresses.items() if hostname == node.virtual_host %}
+add_ipaddr_{{ virtual_host_interface }}_{{ instance_name }}:
+  file.append:
+    - name: {{ ifcfg_file }}
+    - text: IPADDR_{{ current_iddr }}={{ virtual_ip }}/{{ node.virtual_host_mask|default(24) }}
+    - unless:
+      - cat {{ ifcfg_file }} | grep '{{ virtual_ip }}'
+{% endfor %}
+
 {% endfor %}

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 23 12:31:57 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
+
+- Set the virtual ip addresses as permanent, except for HA scenarios,
+  to have them even after a reboot of the machine
+
+-------------------------------------------------------------------
 Fri Feb 19 08:48:58 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Add some mandatory values in the DB and PAS templates for S4HANA


### PR DESCRIPTION
Fix for: https://github.com/SUSE/sapnwbootstrap-formula/issues/73

Now the virtual ip addresses are set permanently in the `/etc/sysconfig/network/ifcfg-ethX` (the network interface is based on the pillar file).

If the scenario is HA, they are removed later on as the virtual address is managed by the cluster and it cannot be permanent.
In this case, the data is remove from the file. This `add first/remove later` looks better as it will remove the address even if some data is not considered in the pillar file, so it covers more scenarios.

Consider that more than 1 virtual addresses can be used in 1 machine (ASCS and PAS in the same machine for example), that's why we need to loop the data many times.

The `STARTMODE` and `BOOTPROTO` are only changed if they don't have any value (these values are needed to make the network interface permanent, if there are not other configuration values like `dhcp`, etc)