### PR TITLE
add native fencing for microsoft-azure

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">sapnwbootstrap-formula</param>
-    <param name="versionformat">0.6.4+git.%ct.%h</param>
+    <param name="versionformat">0.6.5+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 17 13:56:06 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.6.5
+  * add native fencing for microsoft-azure
+
+-------------------------------------------------------------------
 Fri May 21 12:59:37 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.6.4

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -31,6 +31,8 @@
 {%- set native_fencing = data.native_fencing|default(True) %}
 {%- elif cloud_provider == "microsoft-azure" %}
 {%- set native_fencing = data.native_fencing|default(False) %}
+{%- else %}{# all other cases like openstack and libvirt #}
+{%- set native_fencing = data.native_fencing|default(False) %}
 {%- endif %}
 
 # Platform dependant (stonith, virtual ip address, cib options, etc) resource

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -13,7 +13,6 @@
 {%- set ascs_virtual_host = data.ascs_virtual_host %}
 {%- set ers_virtual_host = data.ers_virtual_host %}
 {%- set monitoring_enabled = pillar.cluster.monitoring_enabled|default(False) %}
-{%- set native_fencing = data.native_fencing|default(True) %}
 {%- set sapmnt_path = data.sapmnt_path|default('/sapmnt') %}
 
 {%- if data.ensa_version is defined %}
@@ -24,6 +23,14 @@
 {%- set ensa_version = grains['ensa_version_'~sid_lower~'_'~ers_instance]|int %}
 {%- else %}
 {%- set ensa_version = 1 %}
+{%- endif %}
+
+{%- if cloud_provider == "amazon-web-services" %}
+{%- set native_fencing = data.native_fencing|default(True) %}
+{%- elif cloud_provider == "google-cloud-platform" %}
+{%- set native_fencing = data.native_fencing|default(True) %}
+{%- elif cloud_provider == "microsoft-azure" %}
+{%- set native_fencing = data.native_fencing|default(False) %}
 {%- endif %}
 
 # Platform dependant (stonith, virtual ip address, cib options, etc) resource

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -90,6 +90,17 @@ primitive rsc_ip_{{ sid }}_ERS{{ ers_instance }} ocf:heartbeat:gcp-vpc-move-rout
 {%- else %}
 
 {%- if cloud_provider == "microsoft-azure" %}
+{%- if native_fencing %}
+property $id="cib-bootstrap-options" \
+    stonith-enabled="true" \
+    stonith-action="off" \
+    concurrent-fencing=true
+
+primitive rsc_azure_stonith_{{ sid }} stonith:fence_azure_arm \
+    params subscriptionId={{ grains['subscription_id'] }} resourceGroup={{ grains['resource_group_name'] }} tenantId={{ grains['tenant_id'] }} login={{ grains['fence_agent_app_id'] }} passwd="{{ grains['fence_agent_client_secret'] }}" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 \
+    op monitor interval=3600 timeout=120 \
+    meta target-role=Started
+{%- endif %}
 
 primitive rsc_socat_{{ sid }}_ASCS{{ ascs_instance }} azure-lb \
   params port=620{{ ascs_instance }} \

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -100,7 +100,6 @@ primitive rsc_ip_{{ sid }}_ERS{{ ers_instance }} ocf:heartbeat:gcp-vpc-move-rout
 {%- if native_fencing %}
 property $id="cib-bootstrap-options" \
     stonith-enabled="true" \
-    stonith-action="off" \
     concurrent-fencing=true
 
 primitive rsc_azure_stonith_{{ sid }} stonith:fence_azure_arm \

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -103,7 +103,7 @@ property $id="cib-bootstrap-options" \
     concurrent-fencing=true
 
 primitive rsc_azure_stonith_{{ sid }} stonith:fence_azure_arm \
-    params subscriptionId={{ grains['subscription_id'] }} resourceGroup={{ grains['resource_group_name'] }} tenantId={{ grains['tenant_id'] }} login={{ grains['fence_agent_app_id'] }} passwd="{{ grains['fence_agent_client_secret'] }}" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 \
+    params subscriptionId={{ data.azure_subscription_id }} resourceGroup={{ data.azure_resource_group_name }} tenantId={{ data.azure_tenant_id }} login={{ data.azure_fence_agent_app_id }} passwd="{{ data.azure_fence_agent_client_secret }}" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 \
     op monitor interval=3600 timeout=120 \
     meta target-role=Started
 {%- endif %}


### PR DESCRIPTION
This adds the needed resources to implement native fencing on azure.

It also defines for all cloud providers the same defaults to use native fencing as https://github.com/SUSE/ha-sap-terraform-deployments/.
```
# ha-sap-terraform-deployments
grep -A5 hana_cluster_fencing_mechanism */variables.tf | grep 'variable |default'
  1:openstack/variables.tf:variable "hana_cluster_fencing_mechanism" {
  4:openstack/variables.tf-  default     = "sbd"
  8:libvirt/variables.tf:variable "hana_cluster_fencing_mechanism" {
  11:libvirt/variables.tf-  default     = "sbd"
  21:gcp/variables.tf:variable "hana_cluster_fencing_mechanism" {
  24:gcp/variables.tf-  default     = "native"
  34:azure/variables.tf:variable "hana_cluster_fencing_mechanism" {
  37:azure/variables.tf-  default     = "sbd"
  47:aws/variables.tf:variable "hana_cluster_fencing_mechanism" {
  50:aws/variables.tf-  default     = "native"
```

```
# this formula
{%- if cloud_provider == "amazon-web-services" %}
{%- set native_fencing = data.native_fencing|default(True) %}
{%- elif cloud_provider == "google-cloud-platform" %}
{%- set native_fencing = data.native_fencing|default(True) %}
{%- elif cloud_provider == "microsoft-azure" %}
{%- set native_fencing = data.native_fencing|default(False) %}
{%- endif %}

```