### PR TITLE
fix monitoring configuration for ASCS and ERS are not available on all hosts

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">sapnwbootstrap-formula</param>
-    <param name="versionformat">0.6.5+git.%ct.%h</param>
+    <param name="versionformat">0.6.6+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/netweaver/monitoring.sls
+++ b/netweaver/monitoring.sls
@@ -6,7 +6,12 @@ prometheus_sap_host_exporter_pkg:
     - name: prometheus-sap_host_exporter
 
 # the sid, instance number pair of a node is unique, so we need to adapt configuration
-{% for node in netweaver.nodes if host == node.host and node.sap_instance != "db" %}
+# do not create configuration for "sap_instance: db"
+{% for node in netweaver.nodes if node.sap_instance != "db" %}
+# create ASCS|ERS|PAS|AAS configuration in non-HA use case
+# OR create both ASCS and ERS configuration in HA use case
+#   AND deploy PAS exporter on ASCS/PAS host if no dedicated PAS host is used
+{% if (not netweaver.ha_enabled and host == node.host) or (netweaver.ha_enabled and (node.sap_instance in ['ascs', 'ers'] or host == node.host)) %}
 {% set sap_instance_nr = '{:0>2}'.format(node.instance) %}
 {% set exporter_instance = '{}_{}{}'.format(node.sid, node.sap_instance.upper(), sap_instance_nr) %}
 {% set instance_name = node.sid~'_'~sap_instance_nr %}
@@ -20,17 +25,22 @@ sap_host_exporter_configuration_{{ exporter_instance }}:
          sap-control-uds: /tmp/.sapstream5{{ sap_instance_nr }}13
     - require:
       - pkg: prometheus_sap_host_exporter_pkg
-      - netweaver_install_{{ instance_name }}
 
+# do not run ASCS and ERS exporter service in HA use case (handled by pacemaker)
+# only run PAS exporter in HA use case (if no dedicated PAS host is used)
+{% if not netweaver.ha_enabled or node.sap_instance == 'pas' %}
 sap_host_exporter_service_{{ exporter_instance }}:
   service.running:
     - name: prometheus-sap_host_exporter@{{ exporter_instance }}
-    - enable: {{ not netweaver.ha_enabled }}
+    - enable: True
     - restart: True
     - require:
+      - netweaver_install_{{ instance_name }}
       - pkg: prometheus_sap_host_exporter_pkg
       - file: sap_host_exporter_configuration_{{ exporter_instance }}
     - watch:
       - file: sap_host_exporter_configuration_{{ exporter_instance }}
+{% endif %}
 
+{% endif %}
 {% endfor %}

--- a/netweaver/monitoring.sls
+++ b/netweaver/monitoring.sls
@@ -11,8 +11,8 @@ prometheus_sap_host_exporter_pkg:
 {% for node in netweaver.nodes if host == node.host or (netweaver.ha_enabled and node.sap_instance in ['ascs', 'ers']) and node.sap_instance != "db" %}
 
 {% set sap_instance_nr = '{:0>2}'.format(node.instance) %}
-{% set exporter_instance = '{}_{}{}'.format(node.sid, node.sap_instance.upper(), sap_instance_nr) %}
-{% set instance_name = node.sid~'_'~sap_instance_nr %}
+{% set exporter_instance = '{}_{}{}'.format(node.sid.upper(), node.sap_instance.upper(), sap_instance_nr) %}
+{% set instance_name = node.sid.upper()~'_'~sap_instance_nr %}
 
 # we bind each exporter instance to a SAP instance virtual host
 sap_host_exporter_configuration_{{ exporter_instance }}:
@@ -26,7 +26,7 @@ sap_host_exporter_configuration_{{ exporter_instance }}:
 # on HA use case deploy ASCS|ERS on ERS|ASCS
 {% if netweaver.ha_enabled and node.sap_instance in ["ascs", "ers"] %}
     - onlyif:
-      - test -d /usr/sap/{{ node.sid }}/ASCS* || test -d /usr/sap/{{ node.sid }}/ERS*
+      - test -d /usr/sap/{{ node.sid.upper() }}/ASCS* || test -d /usr/sap/{{ node.sid.upper() }}/ERS*
 {% endif %}
 
 # do not enable ASCS and ERS exporter service in HA use case (handled by pacemaker)
@@ -49,7 +49,7 @@ sap_host_exporter_service_{{ exporter_instance }}:
 # on HA use case deploy ASCS|ERS on ERS|ASCS
 {% if netweaver.ha_enabled and node.sap_instance in ["ascs", "ers"] %}
     - onlyif:
-      - test -d /usr/sap/{{ node.sid }}/ASCS* || test -d /usr/sap/{{ node.sid }}/ERS*
+      - test -d /usr/sap/{{ node.sid.upper() }}/ASCS* || test -d /usr/sap/{{ node.sid.upper() }}/ERS*
 # on non-HA use case watch file for changes (not possible for disabled service)
 {% else %}
     - watch:

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul  7 13:32:06 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.6.6
+  * fix sap_host_exporter to run on both HA nodes
+
+-------------------------------------------------------------------
 Thu Jun 17 13:56:06 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
 
 - Version bump 0.6.5


### PR DESCRIPTION
[SUSE/ha-sap-terraform-deployments/issues/712](https://github.com/SUSE/ha-sap-terraform-deployments/issues/712) describes that there is no monitoring configuration for the ASCS/ERS nodes after a failover.
The pacemaker cluster already handles this correctly but a local config file for the instance on the nodes in `/etc/sap_host_exporter` is missing. Only the instances that are installed get a monitoring configuration at the moment.

This PR fixes this by ...

- creating ASCS|ERS|PAS|AAS monitoring configuration in non-HA use case
- OR create both ASCS and ERS monitoring configuration in HA use case
  - AND deploy PAS exporter on ASCS/PAS host if no dedicated PAS host is used

- not running ASCS and ERS exporter service in HA use case (handled by pacemaker)
  - AND/OR only run PAS exporter in HA use case (if no dedicated PAS host is used)