### PR TITLE
fix non-existing procedure file when running NW import on a HANA scale-out system

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">sapnwbootstrap-formula</param>
-    <param name="versionformat">0.6.6+git.%ct.%h</param>
+    <param name="versionformat">0.6.7+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 27 08:19:27 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.6.7
+  * fix non-existing procedure file when running NW import on
+    a HANA scale-out system
+
+-------------------------------------------------------------------
 Thu Jul  7 13:32:06 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
 
 - Version bump 0.6.6

--- a/templates/db.inifile.params.j2
+++ b/templates/db.inifile.params.j2
@@ -181,7 +181,8 @@ NW_readProfileDir.profileDir = {{ sapmnt_path }}/{{ sid.upper() }}/profile/
 archives.downloadBasket = {{ download_basket }}
 
 # Specify whether a Landscape Reorg Check Procedures file 'HdbLandscapeReorgCheckProcedure.SQL' is to be used. Possible values are 'USEFILE', 'DONOTUSEFILE','DONOTRUN'. Default value is 'USEFILE'.
-# hanadb.landscape.reorg.useCheckProcedureFile = USEFILE
+# On HANA scale-out deployments sapinst will throw an error message about a missing 'HdbLandscapeReorgCheckProcedure.SQL' file, therefore we set this to DONOTUSEFILE.
+hanadb.landscape.reorg.useCheckProcedureFile = DONOTUSEFILE
 
 # Specify whether a Table Placement Parameters file 'HdbTablePlacementParameters.SQL' is to be used. Possible values are 'USEFILE', 'DONOTUSEFILE'. Default value is 'USEFILE'.
 hanadb.landscape.reorg.useParameterFile = DONOTUSEFILE


### PR DESCRIPTION
`sapinst` for DB import complains about missing `HdbLandscapeReorgCheckProcedure.SQL` file on scale-out deployments.
The `DONOTUSEFILE` parameter prevents using this file and the import works.