### PR TITLE
load-balancer setup for GCP and streamlined resource template for HANA, Netweaver, DRBD

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">sapnwbootstrap-formula</param>
-    <param name="versionformat">0.6.7+git.%ct.%h</param>
+    <param name="versionformat">0.7.0+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/form.yml
+++ b/form.yml
@@ -1,3 +1,4 @@
+# https://documentation.suse.com/external-tree/en-us/suma/4.0/suse-manager/salt/formulas-custom.html
 netweaver:
   $name: Netweaver
   $type: group

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Thu Nov 17 13:52:34 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.7.0
+  * add option to enable load-balancer for GCP
+  * define vip_mechanism for every provider and reorder resources
+    (same schema for all SAP related formulas)
+  * change SAPInstance monitoring interval to 11s as mentioned in docs
+  * fix colocation name
+  * add link to SUSE Manager documentation
+
+-------------------------------------------------------------------
 Thu Aug 27 08:19:27 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
 
 - Version bump 0.6.7

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -29,6 +29,7 @@
 {%- set native_fencing = data.native_fencing|default(True) %}
 {%- elif cloud_provider == "google-cloud-platform" %}
 {%- set native_fencing = data.native_fencing|default(True) %}
+{%- set vip_mechanism = data.virtual_ip_mechanism|default("load-balancer") %}
 {%- elif cloud_provider == "microsoft-azure" %}
 {%- set native_fencing = data.native_fencing|default(False) %}
 {%- else %}{# all other cases like openstack and libvirt #}
@@ -84,6 +85,22 @@ primitive rsc_gcp_stonith_{{ sid }}_{{ grains['host'] }} stonith:fence_gce \
     meta target-role=Started
 {%- endif %}
 
+{%- if vip_mechanism == "load-balancer" %}
+
+primitive rsc_socat_{{ sid }}_ASCS{{ ascs_instance }} anything \
+    params binfile="/usr/bin/socat" \
+    cmdline_options="-U TCP-LISTEN:620{{ ascs_instance }},backlog=10,fork,reuseaddr /dev/null" \
+    op monitor timeout=20s interval=10 \
+    op_params depth=0
+
+primitive rsc_socat_{{ sid }}_ERS{{ ers_instance }} anything \
+    params binfile="/usr/bin/socat" \
+    cmdline_options="-U TCP-LISTEN:621{{ ers_instance }},backlog=10,fork,reuseaddr /dev/null" \
+    op monitor timeout=20s interval=10 \
+    op_params depth=0
+
+{%- elif vip_mechanism == "route" %}
+
 primitive rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} ocf:heartbeat:gcp-vpc-move-route \
     params ip={{ data.ascs_ip_address }} vpc_network={{ data.vpc_network_name }} route_name={{ data.ascs_route_name|default("nw-ascs-"~sid~"-route") }} \
     op start interval=0 timeout=180 \
@@ -96,9 +113,9 @@ primitive rsc_ip_{{ sid }}_ERS{{ ers_instance }} ocf:heartbeat:gcp-vpc-move-rout
     op stop interval=0 timeout=180 \
     op monitor interval=60 timeout=60
 
-{%- else %}
+{%- endif %}
 
-{%- if cloud_provider == "microsoft-azure" %}
+{%- elif cloud_provider == "microsoft-azure" %}
 {%- if native_fencing %}
 property $id="cib-bootstrap-options" \
     stonith-enabled="true" \
@@ -118,7 +135,7 @@ primitive rsc_socat_{{ sid }}_ERS{{ ers_instance }} azure-lb \
   params port=621{{ ers_instance }} \
   op monitor timeout=20s interval=10 depth=0
 
-{%- endif %}
+{%- else %}
 
 primitive rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} IPaddr2 \
   params ip={{ ascs_ip_address}} \
@@ -169,7 +186,9 @@ group grp_{{ sid }}_ASCS{{ ascs_instance }} \
   rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} \
   rsc_fs_{{ sid }}_ASCS{{ ascs_instance }} \
   rsc_sap_{{ sid }}_ASCS{{ ascs_instance }} \
-  {%- if cloud_provider == "microsoft-azure" %}
+  {%- if cloud_provider == "google-cloud-platform" and vip_mechanism == "load-balancer" %}
+  rsc_socat_{{ sid }}_ASCS{{ ascs_instance }} \
+  {%- elif cloud_provider == "microsoft-azure" %}
   rsc_socat_{{ sid }}_ASCS{{ ascs_instance }} \
   {%- endif %}
   {%- if monitoring_enabled %}
@@ -196,11 +215,13 @@ primitive rsc_sap_{{ sid }}_ERS{{ ers_instance }} SAPInstance \
 group grp_{{ sid }}_ERS{{ ers_instance }} \
   rsc_ip_{{ sid }}_ERS{{ ers_instance }} \
   rsc_fs_{{ sid }}_ERS{{ ers_instance }} \
-  rsc_sap_{{ sid }}_ERS{{ ers_instance }}
-  {%- if cloud_provider == "microsoft-azure" %} \
-  rsc_socat_{{ sid }}_ERS{{ ers_instance }}
+  rsc_sap_{{ sid }}_ERS{{ ers_instance }} \
+  {%- if cloud_provider == "google-cloud-platform" and vip_mechanism == "load-balancer" %}
+  rsc_socat_{{ sid }}_ERS{{ ers_instance }} \
+  {%- elif cloud_provider == "microsoft-azure" %}
+  rsc_socat_{{ sid }}_ERS{{ ers_instance }} \
   {%- endif %}
-  {%- if monitoring_enabled %} \
+  {%- if monitoring_enabled %}
   rsc_exporter_{{ sid }}_ERS{{ ers_instance }}
   {%- endif %}
 

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -176,7 +176,7 @@ primitive rsc_fs_{{ sid }}_ASCS{{ ascs_instance }} Filesystem \
 
 primitive rsc_sap_{{ sid }}_ASCS{{ ascs_instance }} SAPInstance \
   operations $id=rsc_sap_{{ sid }}_ASCS{{ ascs_instance }}-operations \
-  op monitor interval=120 timeout=60 on_fail=restart \
+  op monitor interval=11 timeout=60 on-fail=restart \
   params InstanceName={{ sid }}_ASCS{{ ascs_instance }}_{{ ascs_virtual_host }} \
      START_PROFILE="{{ sapmnt_path }}/{{ sid }}/profile/{{ sid }}_ASCS{{ ascs_instance }}_{{ ascs_virtual_host }}" \
      AUTOMATIC_RECOVER=false \
@@ -207,7 +207,7 @@ primitive rsc_fs_{{ sid }}_ERS{{ ers_instance }} Filesystem \
 
 primitive rsc_sap_{{ sid }}_ERS{{ ers_instance }} SAPInstance \
   operations $id=rsc_sap_{{ sid }}_ERS{{ ers_instance }}-operations \
-  op monitor interval=120 timeout=60 on_fail=restart \
+  op monitor interval=11 timeout=60 on-fail=restart \
   params InstanceName={{ sid }}_ERS{{ ers_instance }}_{{ ers_virtual_host }} \
         START_PROFILE="{{ sapmnt_path }}/{{ sid }}/profile/{{ sid }}_ERS{{ ers_instance }}_{{ ers_virtual_host }}" \
         AUTOMATIC_RECOVER=false IS_ERS=true {% if ensa_version == 1 %}meta priority=1000{%- endif %}

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -225,7 +225,7 @@ group grp_{{ sid }}_ERS{{ ers_instance }} \
   rsc_exporter_{{ sid }}_ERS{{ ers_instance }}
   {%- endif %}
 
-colocation col_sap_{{ sid }}_no_both -5000: grp_{{ sid }}_ERS{{ ers_instance }} grp_{{ sid }}_ASCS{{ ascs_instance }}
+colocation col_sap_{{ sid }}_not_both -5000: grp_{{ sid }}_ERS{{ ers_instance }} grp_{{ sid }}_ASCS{{ ascs_instance }}
 {%- if ensa_version == 1 %}
 location loc_sap_{{ sid }}_failover_to_ers rsc_sap_{{ sid }}_ASCS{{ ascs_instance }} \
   rule 2000: runs_ers_{{ sid }} eq 1

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -27,143 +27,152 @@
 
 {%- if cloud_provider == "amazon-web-services" %}
 {%- set native_fencing = data.native_fencing|default(True) %}
+{%- set vip_mechanism = data.virtual_ip_mechanism|default("route") %}
 {%- elif cloud_provider == "google-cloud-platform" %}
 {%- set native_fencing = data.native_fencing|default(True) %}
 {%- set vip_mechanism = data.virtual_ip_mechanism|default("load-balancer") %}
 {%- elif cloud_provider == "microsoft-azure" %}
 {%- set native_fencing = data.native_fencing|default(False) %}
+{%- set vip_mechanism = data.virtual_ip_mechanism|default("load-balancer") %}
 {%- else %}{# all other cases like openstack and libvirt #}
 {%- set native_fencing = data.native_fencing|default(False) %}
+{%- set vip_mechanism = data.virtual_ip_mechanism|default("vip-only") %}
 {%- endif %}
+{%- set cidr_netmask = "cidr_netmask="~data.virtual_ip_mask|default("32") %}
+{%- set nic = "nic="~pillar.cluster.interface|json if pillar.cluster.interface is defined else "" %}
 
-# Platform dependant (stonith, virtual ip address, cib options, etc) resource
+###########
+# Defaults
+###########
 
 {%- if cloud_provider == "amazon-web-services" %}
 
-rsc_defaults rsc-options: \
-	resource-stickiness=1 \
-	migration-threshold=3
+  rsc_defaults rsc-options: \
+    resource-stickiness=1 \
+    migration-threshold=3
 
-op_defaults op-options: \
-	timeout=600 \
-	record-pending=true
-
-{%- if native_fencing %}
-property cib-bootstrap-options: \
-  stonith-enabled="true" \
-  stonith-action="off" \
-  stonith-timeout="600s"
-
-primitive res_aws_stonith_{{ sid }} stonith:external/ec2 \
-  params tag={{ data.instance_tag }} profile={{ data.cluster_profile}} \
-  op start interval=0 timeout=180 \
-  op stop interval=0 timeout=180 \
-  op monitor interval=120 timeout=60 \
-  meta target-role=Started
+  op_defaults op-options: \
+    timeout=600 \
+    record-pending=true
 {%- endif %}
 
-primitive rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} ocf:suse:aws-vpc-move-ip \
-  params ip={{ ascs_ip_address }} routing_table={{ data.route_table}} \
-  interface={{ pillar.cluster.interface|default('eth0')|json }} profile={{ data.cluster_profile}} \
-  op start interval=0 timeout=180 \
-  op stop interval=0 timeout=180 \
-  op monitor interval=60 timeout=60
+#####################################################
+# Fencing agents - Native agents for cloud providers
+#####################################################
 
-primitive rsc_ip_{{ sid }}_ERS{{ ers_instance }} ocf:suse:aws-vpc-move-ip \
-  params ip={{ ers_ip_address }} routing_table={{ data.route_table}} \
-  interface={{ pillar.cluster.interface|default('eth0')|json }} profile={{ data.cluster_profile}} \
-  op start interval=0 timeout=180 \
-  op stop interval=0 timeout=180 \
-  op monitor interval=60 timeout=60
+{%- if native_fencing %}
+  {%- if cloud_provider == "amazon-web-services" %}
+    property cib-bootstrap-options: \
+      stonith-enabled="true" \
+      stonith-action="off" \
+      stonith-timeout="600s"
+
+    primitive res_aws_stonith_{{ sid }} stonith:external/ec2 \
+      params tag={{ data.instance_tag }} profile={{ data.cluster_profile}} \
+      op start interval=0 timeout=180 \
+      op stop interval=0 timeout=180 \
+      op monitor interval=120 timeout=60 \
+      meta target-role=Started
+
+  {%- elif cloud_provider == "google-cloud-platform" %}
+    property $id="cib-bootstrap-options" \
+      stonith-enabled="true" \
+      stonith-timeout="150s"
+
+    # This stonith resource will be duplicated for each node in the cluster
+    primitive rsc_gcp_stonith_{{ sid }}_{{ grains['host'] }} stonith:fence_gce \
+      params plug={{ grains['gcp_instance_name'] }} pcmk_host_map="{{ grains['host'] }}:{{ grains['gcp_instance_name'] }}" \
+      meta target-role=Started
+
+  {%- elif cloud_provider == "microsoft-azure" %}
+    property $id="cib-bootstrap-options" \
+      stonith-enabled="true" \
+      concurrent-fencing=true
+
+    primitive rsc_azure_stonith_{{ sid }} stonith:fence_azure_arm \
+      params subscriptionId={{ data.azure_subscription_id }} resourceGroup={{ data.azure_resource_group_name }} tenantId={{ data.azure_tenant_id }} login={{ data.azure_fence_agent_app_id }} passwd="{{ data.azure_fence_agent_client_secret }}" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 \
+      op monitor interval=3600 timeout=120 \
+      meta target-role=Started
+  {%- endif %}
+{%- endif %}
+
+######################################
+# Floating IP address resource agents
+######################################
+
+{%- if cloud_provider == "amazon-web-services" %}
+  {%- if vip_mechanism == "route" %}
+    primitive rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} ocf:suse:aws-vpc-move-ip \
+      params ip={{ ascs_ip_address }} routing_table={{ data.route_table}} \
+      interface={{ pillar.cluster.interface|default('eth0')|json }} profile={{ data.cluster_profile}} \
+      op start interval=0 timeout=180 \
+      op stop interval=0 timeout=180 \
+      op monitor interval=60 timeout=60
+
+    primitive rsc_ip_{{ sid }}_ERS{{ ers_instance }} ocf:suse:aws-vpc-move-ip \
+      params ip={{ ers_ip_address }} routing_table={{ data.route_table}} \
+      interface={{ pillar.cluster.interface|default('eth0')|json }} profile={{ data.cluster_profile}} \
+      op start interval=0 timeout=180 \
+      op stop interval=0 timeout=180 \
+      op monitor interval=60 timeout=60
+  {%- endif %}
 
 {%- elif cloud_provider == "google-cloud-platform" %}
 
-{%- if native_fencing %}
-# This stonith resource will be duplicated for each node in the cluster
-primitive rsc_gcp_stonith_{{ sid }}_{{ grains['host'] }} stonith:fence_gce \
-    params plug={{ grains['gcp_instance_name'] }} pcmk_host_map="{{ grains['host'] }}:{{ grains['gcp_instance_name'] }}" \
-    meta target-role=Started
-{%- endif %}
+  {%- if vip_mechanism == "load-balancer" %}
+    primitive rsc_socat_{{ sid }}_ASCS{{ ascs_instance }} anything \
+      params binfile="/usr/bin/socat" \
+      cmdline_options="-U TCP-LISTEN:620{{ ascs_instance }},backlog=10,fork,reuseaddr /dev/null" \
+      op monitor timeout=20s interval=10 \
+      op_params depth=0
 
-{%- if vip_mechanism == "load-balancer" %}
+    primitive rsc_socat_{{ sid }}_ERS{{ ers_instance }} anything \
+      params binfile="/usr/bin/socat" \
+      cmdline_options="-U TCP-LISTEN:621{{ ers_instance }},backlog=10,fork,reuseaddr /dev/null" \
+      op monitor timeout=20s interval=10 \
+      op_params depth=0
 
-primitive rsc_socat_{{ sid }}_ASCS{{ ascs_instance }} anything \
-    params binfile="/usr/bin/socat" \
-    cmdline_options="-U TCP-LISTEN:620{{ ascs_instance }},backlog=10,fork,reuseaddr /dev/null" \
-    op monitor timeout=20s interval=10 \
-    op_params depth=0
+  {%- elif vip_mechanism == "route" %}
+    primitive rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} ocf:heartbeat:gcp-vpc-move-route \
+      params ip={{ data.ascs_ip_address }} vpc_network={{ data.vpc_network_name }} route_name={{ data.ascs_route_name|default("nw-ascs-"~sid~"-route") }} \
+      op start interval=0 timeout=180 \
+      op stop interval=0 timeout=180 \
+      op monitor interval=60 timeout=60
 
-primitive rsc_socat_{{ sid }}_ERS{{ ers_instance }} anything \
-    params binfile="/usr/bin/socat" \
-    cmdline_options="-U TCP-LISTEN:621{{ ers_instance }},backlog=10,fork,reuseaddr /dev/null" \
-    op monitor timeout=20s interval=10 \
-    op_params depth=0
-
-{%- elif vip_mechanism == "route" %}
-
-primitive rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} ocf:heartbeat:gcp-vpc-move-route \
-    params ip={{ data.ascs_ip_address }} vpc_network={{ data.vpc_network_name }} route_name={{ data.ascs_route_name|default("nw-ascs-"~sid~"-route") }} \
-    op start interval=0 timeout=180 \
-    op stop interval=0 timeout=180 \
-    op monitor interval=60 timeout=60
-
-primitive rsc_ip_{{ sid }}_ERS{{ ers_instance }} ocf:heartbeat:gcp-vpc-move-route \
-    params ip={{ data.ers_ip_address }} vpc_network={{ data.vpc_network_name }} route_name={{ data.ers_route_name|default("nw-ers-"~sid~"-route") }} \
-    op start interval=0 timeout=180 \
-    op stop interval=0 timeout=180 \
-    op monitor interval=60 timeout=60
-
-{%- endif %}
+    primitive rsc_ip_{{ sid }}_ERS{{ ers_instance }} ocf:heartbeat:gcp-vpc-move-route \
+      params ip={{ data.ers_ip_address }} vpc_network={{ data.vpc_network_name }} route_name={{ data.ers_route_name|default("nw-ers-"~sid~"-route") }} \
+      op start interval=0 timeout=180 \
+      op stop interval=0 timeout=180 \
+      op monitor interval=60 timeout=60
+  {%- endif %}
 
 {%- elif cloud_provider == "microsoft-azure" %}
-{%- if native_fencing %}
-property $id="cib-bootstrap-options" \
-    stonith-enabled="true" \
-    concurrent-fencing=true
 
-primitive rsc_azure_stonith_{{ sid }} stonith:fence_azure_arm \
-    params subscriptionId={{ data.azure_subscription_id }} resourceGroup={{ data.azure_resource_group_name }} tenantId={{ data.azure_tenant_id }} login={{ data.azure_fence_agent_app_id }} passwd="{{ data.azure_fence_agent_client_secret }}" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 \
-    op monitor interval=3600 timeout=120 \
-    meta target-role=Started
-{%- endif %}
+  {%- if vip_mechanism == "load-balancer" %}
+    primitive rsc_socat_{{ sid }}_ASCS{{ ascs_instance }} azure-lb \
+      params port=620{{ ascs_instance }} \
+      op monitor timeout=20s interval=10 depth=0
 
-primitive rsc_socat_{{ sid }}_ASCS{{ ascs_instance }} azure-lb \
-  params port=620{{ ascs_instance }} \
-  op monitor timeout=20s interval=10 depth=0
-
-primitive rsc_socat_{{ sid }}_ERS{{ ers_instance }} azure-lb \
-  params port=621{{ ers_instance }} \
-  op monitor timeout=20s interval=10 depth=0
-
-{%- else %}
-
-primitive rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} IPaddr2 \
-  params ip={{ ascs_ip_address}} \
-  op monitor interval=10s timeout=20s
-
-primitive rsc_ip_{{ sid }}_ERS{{ ers_instance }} IPaddr2 \
-  params ip={{ ers_ip_address }} \
-  op monitor interval=10s timeout=20s
+    primitive rsc_socat_{{ sid }}_ERS{{ ers_instance }} azure-lb \
+      params port=621{{ ers_instance }} \
+      op monitor timeout=20s interval=10 depth=0
+  {%- endif %}
 
 {%- endif %}
 
-{%- if monitoring_enabled %}
+{%- if vip_mechanism == "vip-only" or vip_mechanism == "load-balancer" %}
+  primitive rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} IPaddr2 \
+    params ip={{ ascs_ip_address }} {{ cidr_netmask }} {{ nic }} \
+    op monitor interval=10s timeout=20s
 
-primitive rsc_exporter_{{ sid }}_ASCS{{ ascs_instance }} systemd:prometheus-sap_host_exporter@{{ sid }}_ASCS{{ ascs_instance }} \
-    op start interval=0 timeout=100 \
-    op stop interval=0 timeout=100 \
-    op monitor interval=10 \
-    meta target-role=Started
-
-primitive rsc_exporter_{{ sid }}_ERS{{ ers_instance }} systemd:prometheus-sap_host_exporter@{{ sid }}_ERS{{ ers_instance }} \
-    op start interval=0 timeout=100 \
-    op stop interval=0 timeout=100 \
-    op monitor interval=10 \
-    meta target-role=Started
-
+  primitive rsc_ip_{{ sid }}_ERS{{ ers_instance }} IPaddr2 \
+    params ip={{ ers_ip_address }} {{ cidr_netmask }} {{ nic }} \
+    op monitor interval=10s timeout=20s
 {%- endif %}
 
-# SAP Netweaver related resources
+##########################
+# SAP Netweaver resources
+##########################
 
 primitive rsc_fs_{{ sid }}_ASCS{{ ascs_instance }} Filesystem \
   params device="{{ ascs_device }}" directory="/usr/sap/{{ sid }}/ASCS{{ ascs_instance }}" fstype={{ ascs_fstype|default("xfs") }} \
@@ -178,17 +187,15 @@ primitive rsc_sap_{{ sid }}_ASCS{{ ascs_instance }} SAPInstance \
   operations $id=rsc_sap_{{ sid }}_ASCS{{ ascs_instance }}-operations \
   op monitor interval=11 timeout=60 on-fail=restart \
   params InstanceName={{ sid }}_ASCS{{ ascs_instance }}_{{ ascs_virtual_host }} \
-     START_PROFILE="{{ sapmnt_path }}/{{ sid }}/profile/{{ sid }}_ASCS{{ ascs_instance }}_{{ ascs_virtual_host }}" \
-     AUTOMATIC_RECOVER=false \
+    START_PROFILE="{{ sapmnt_path }}/{{ sid }}/profile/{{ sid }}_ASCS{{ ascs_instance }}_{{ ascs_virtual_host }}" \
+    AUTOMATIC_RECOVER=false \
   meta resource-stickiness=5000 {% if ensa_version == 1 %}failure-timeout=60 migration-threshold=1 priority=10{%- endif %}
 
 group grp_{{ sid }}_ASCS{{ ascs_instance }} \
   rsc_ip_{{ sid }}_ASCS{{ ascs_instance }} \
   rsc_fs_{{ sid }}_ASCS{{ ascs_instance }} \
   rsc_sap_{{ sid }}_ASCS{{ ascs_instance }} \
-  {%- if cloud_provider == "google-cloud-platform" and vip_mechanism == "load-balancer" %}
-  rsc_socat_{{ sid }}_ASCS{{ ascs_instance }} \
-  {%- elif cloud_provider == "microsoft-azure" %}
+  {%- if vip_mechanism == "load-balancer" %}
   rsc_socat_{{ sid }}_ASCS{{ ascs_instance }} \
   {%- endif %}
   {%- if monitoring_enabled %}
@@ -209,16 +216,14 @@ primitive rsc_sap_{{ sid }}_ERS{{ ers_instance }} SAPInstance \
   operations $id=rsc_sap_{{ sid }}_ERS{{ ers_instance }}-operations \
   op monitor interval=11 timeout=60 on-fail=restart \
   params InstanceName={{ sid }}_ERS{{ ers_instance }}_{{ ers_virtual_host }} \
-        START_PROFILE="{{ sapmnt_path }}/{{ sid }}/profile/{{ sid }}_ERS{{ ers_instance }}_{{ ers_virtual_host }}" \
-        AUTOMATIC_RECOVER=false IS_ERS=true {% if ensa_version == 1 %}meta priority=1000{%- endif %}
+    START_PROFILE="{{ sapmnt_path }}/{{ sid }}/profile/{{ sid }}_ERS{{ ers_instance }}_{{ ers_virtual_host }}" \
+    AUTOMATIC_RECOVER=false IS_ERS=true {% if ensa_version == 1 %}meta priority=1000{%- endif %}
 
 group grp_{{ sid }}_ERS{{ ers_instance }} \
   rsc_ip_{{ sid }}_ERS{{ ers_instance }} \
   rsc_fs_{{ sid }}_ERS{{ ers_instance }} \
   rsc_sap_{{ sid }}_ERS{{ ers_instance }} \
-  {%- if cloud_provider == "google-cloud-platform" and vip_mechanism == "load-balancer" %}
-  rsc_socat_{{ sid }}_ERS{{ ers_instance }} \
-  {%- elif cloud_provider == "microsoft-azure" %}
+  {%- if vip_mechanism == "load-balancer" %}
   rsc_socat_{{ sid }}_ERS{{ ers_instance }} \
   {%- endif %}
   {%- if monitoring_enabled %}
@@ -233,3 +238,21 @@ location loc_sap_{{ sid }}_failover_to_ers rsc_sap_{{ sid }}_ASCS{{ ascs_instanc
 
 order ord_sap_{{ sid }}_first_start_ascs Optional: rsc_sap_{{ sid }}_ASCS{{ ascs_instance }}:start \
   rsc_sap_{{ sid }}_ERS{{ ers_instance }}:stop symmetrical=false
+
+#########################################
+# prometheus-sap_host_exporter resources
+#########################################
+
+{%- if monitoring_enabled %}
+  primitive rsc_exporter_{{ sid }}_ASCS{{ ascs_instance }} systemd:prometheus-sap_host_exporter@{{ sid }}_ASCS{{ ascs_instance }} \
+    op start interval=0 timeout=100 \
+    op stop interval=0 timeout=100 \
+    op monitor interval=10 \
+    meta target-role=Started
+
+  primitive rsc_exporter_{{ sid }}_ERS{{ ers_instance }} systemd:prometheus-sap_host_exporter@{{ sid }}_ERS{{ ers_instance }} \
+    op start interval=0 timeout=100 \
+    op stop interval=0 timeout=100 \
+    op monitor interval=10 \
+    meta target-role=Started
+{%- endif %}


### PR DESCRIPTION
This PR is part of a series of PRs to enable a load-balancer setup for GCP (Netweaver, DRBD, HANA [already existing]).
The formulas for HANA, Netweaver, DRBD are streamlined to have the same logic to create cluster resources.
PRs: 
* https://github.com/SUSE/saphanabootstrap-formula/pull/137
* https://github.com/SUSE/sapnwbootstrap-formula/pull/91
* https://github.com/SUSE/drbd-formula/pull/28
* https://github.com/SUSE/ha-sap-terraform-deployments/pull/793

* add option to enable load-balancer for GCP
* redesign of cluster resource template
  * define vip_mechanism for every provider and reorder resources
    (same schema for all SAP related formulas)
* change SAPInstance monitoring interval to 11s as mentioned in docs
* fix colocation name -> breaking change
* add link to SUSE Manager documentation

fixes https://github.com/SUSE/ha-sap-terraform-deployments/issues/783
fixes https://github.com/SUSE/ha-sap-terraform-deployments/issues/779