### PR TITLE
backup HANA after initial DB import (if SR is enabled)

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">sapnwbootstrap-formula</param>
-    <param name="versionformat">0.7.2+git.%ct.%h</param>
+    <param name="versionformat">0.7.3+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/netweaver/install_db.sls
+++ b/netweaver/install_db.sls
@@ -92,4 +92,17 @@ remove_db_inifile_{{ instance_name }}:
     - require:
       - create_db_inifile_{{ instance_name }}
 
+{%- if netweaver.hana.ha_enabled|default(false) is sameas true %}
+backup_db_{{ netweaver.hana.host }}_{{ netweaver.hana.sid }}_{{ hana_instance }}:
+  module.run:
+    - hana.query:
+      - host: {{ netweaver.hana.host }}
+      - port: 3{{ hana_instance }}13
+      - user: SYSTEM
+      - password: {{ netweaver.hana.password }}
+      - query: "BACKUP DATA FOR FULL SYSTEM USING FILE ('post_db_import')"
+    - require:
+      - netweaver_install_{{ instance_name }}
+{%- endif %}
+
 {% endfor %}

--- a/netweaver/install_db.sls
+++ b/netweaver/install_db.sls
@@ -92,7 +92,7 @@ remove_db_inifile_{{ instance_name }}:
     - require:
       - create_db_inifile_{{ instance_name }}
 
-{%- if netweaver.hana.ha_enabled|default(false) is sameas true %}
+{%- if netweaver.hana.sr_enabled|default(false) is sameas true %}
 backup_db_{{ netweaver.hana.host }}_{{ netweaver.hana.sid }}_{{ hana_instance }}:
   module.run:
     - hana.query:

--- a/sapnwbootstrap-formula.changes
+++ b/sapnwbootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 03 15:17:42 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.7.3
+  * backup HANA after initial DB import if SR is enabled
+
+-------------------------------------------------------------------
 Tue Feb 02 14:30:21 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
 
 - Version bump 0.7.2


### PR DESCRIPTION
This adds the feature of creating a HANA DB backup after the initial "Netweaver / S/4HANA import" is done (if HANA SR is enabled).
It uses a new pillar switch called `netweaver.hana.ha_enabled` for this, which can later be set via a grain.

After the very large initial "Netweaver / S/4HANA import", the 1st backup on the HANA (done by `saphanabootstrap-formula`) differs to much to re-initiate HANA System Replication. This is why this new backup is needed.

## helps to fix
https://github.com/SUSE/ha-sap-terraform-deployments/issues/739
https://github.com/SUSE/ha-sap-terraform-deployments/issues/803

## prerequisites
`salt-shaptools-0.3.14` including these fixes:
https://github.com/SUSE/salt-shaptools/pull/84
https://github.com/SUSE/salt-shaptools/pull/86